### PR TITLE
[김기표]w2-리뷰요청_스타일컴포넌트를활용한레이아웃구현

### DIFF
--- a/client/review/App.tsx
+++ b/client/review/App.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Route, Switch, BrowserRouter } from "react-router-dom";
+import { createBrowserHistory } from "history";
+import { Snug } from "./page/snug";
+import { Application } from "./context.instance";
+import { createGlobalStyle } from "styled-components";
+
+const GlobalStyle = createGlobalStyle`
+    body{
+        padding: 0;
+        margin: 0;
+        background:yellow;
+    }
+    #root{
+      width:100vw;
+      height:100vh;
+    }
+`;
+
+const App: React.FC = () => {
+  const history = createBrowserHistory();
+  return (
+    <BrowserRouter>
+      <GlobalStyle></GlobalStyle>
+      <Switch>
+        <Route
+          exact
+          path="/"
+          component={(props: any) => (
+            <Snug {...props} Application={Application}></Snug>
+          )}
+        ></Route>
+      </Switch>
+    </BrowserRouter>
+  );
+};
+
+export default App;

--- a/client/review/components/chat-content.tsx
+++ b/client/review/components/chat-content.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import styled from "styled-components";
+
+const ChatContentWrapper = styled.section`
+  height: 100%;
+  width: 100%;
+`;
+
+export const ChatContent: React.FC = () => {
+  return <ChatContentWrapper>채팅</ChatContentWrapper>;
+};

--- a/client/review/components/chat-input-box.tsx
+++ b/client/review/components/chat-input-box.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import styled from "styled-components";
+import ClipWhite from "../../assets/clip-white.png";
+import AtWhite from "../../assets/at-white.png";
+import FaceWhite from "../../assets/face-white.png";
+import { IconBox } from "./icon-box";
+
+const InputWrapper = styled.section`
+  width: 100%;
+  height: 75px;
+  background-color: grey;
+  padding-top: 10px;
+  padding-bottom: 20px;
+  box-sizing: border-box;
+  text-align: center;
+  display: flex;
+`;
+
+const MarginBox = styled.section`
+  min-width: 10px;
+  height: 100%;
+`;
+
+const CustomInput = styled.section`
+  width: 100%;
+  border: 1px solid #182226;
+  background-color: #263237;
+  border-radius: 10px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  padding: 5px;
+`;
+
+const StyledInput = styled.input.attrs({
+  placeholder: "메세지를 입력하세요."
+})`
+  --webkit-appearance: none;
+  background-color: #263237;
+  font-size: 14px;
+  color: #e3e3e3;
+  width: 100%;
+  border: none;
+  &:active,
+  :focus {
+    outline: none;
+  }
+`;
+
+export const ChatInputBox: React.FC = () => {
+  return (
+    <InputWrapper>
+      <MarginBox></MarginBox>
+      <CustomInput>
+        <IconBox imageSrc={ClipWhite}></IconBox>
+        <StyledInput></StyledInput>
+        <IconBox imageSrc={AtWhite}></IconBox>
+        <IconBox imageSrc={FaceWhite}></IconBox>
+      </CustomInput>
+      <MarginBox></MarginBox>
+    </InputWrapper>
+  );
+};

--- a/client/review/components/message-section-content.tsx
+++ b/client/review/components/message-section-content.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+import { ChatContent } from "./chat-content";
+import { ChatInputBox } from "./chat-input-box";
+
+const MessageSectionContentWrapper = styled.section`
+  width: 100%;
+  height: 100%;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const MessageSectionContent: React.FC = () => {
+  return (
+    <MessageSectionContentWrapper>
+      <ChatContent></ChatContent>
+      <ChatInputBox></ChatInputBox>
+    </MessageSectionContentWrapper>
+  );
+};

--- a/client/review/components/message-section-header.tsx
+++ b/client/review/components/message-section-header.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import styled from "styled-components";
+
+const HeaderWrapper = styled.header`
+  background-color: green;
+  min-height: 50px;
+`;
+
+export const MessageSectionHeader: React.FC = () => {
+  return <HeaderWrapper>hi</HeaderWrapper>;
+};

--- a/client/review/components/message-section.tsx
+++ b/client/review/components/message-section.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+import { MessageSectionHeader } from "./message-section-header";
+import { MessageSectionContent } from "./message-section-content";
+
+const MessageSectionWrapper = styled.section`
+  height: 100%;
+  background-color: blue;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const MessageSection: React.FC = () => {
+  return (
+    <MessageSectionWrapper>
+      <MessageSectionHeader></MessageSectionHeader>
+      <MessageSectionContent></MessageSectionContent>
+    </MessageSectionWrapper>
+  );
+};

--- a/client/review/components/sidebar.tsx
+++ b/client/review/components/sidebar.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import styled from "styled-components";
+
+const SidebarWrapper = styled.section`
+  min-width: 250px;
+  height: 100%;
+  background-color: red;
+`;
+
+export const Sidebar: React.FC = () => {
+  return <SidebarWrapper></SidebarWrapper>;
+};

--- a/client/review/components/snug-header.tsx
+++ b/client/review/components/snug-header.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import styled from "styled-components";
+
+const HeaderWrapper = styled.header`
+  min-height: 50px;
+  width: 100%;
+`;
+
+export const SnugHeader: React.FC = () => {
+  return <HeaderWrapper>Header</HeaderWrapper>;
+};

--- a/client/review/context.instance.tsx
+++ b/client/review/context.instance.tsx
@@ -1,0 +1,20 @@
+//의존성 주입
+import { HttpProviderDependencies } from "./@context/http-providers/http-providers";
+import { StorageProviderDependencies } from "./@context/storage-providers/storage-providers";
+import { RepositoryDependencies } from "./@context/repositories/index";
+import { ServiceDependencies } from "./@context/services/index";
+
+class Context {
+  private apies: HttpProviderDependencies;
+  private storages: StorageProviderDependencies;
+  private repositories: RepositoryDependencies;
+  services: ServiceDependencies;
+  constructor() {
+    this.apies = new HttpProviderDependencies();
+    this.storages = new StorageProviderDependencies();
+    this.repositories = new RepositoryDependencies(this.apies, this.storages);
+    this.services = new ServiceDependencies(this.repositories);
+  }
+}
+
+export const Application = new Context();

--- a/client/review/index.tsx
+++ b/client/review/index.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/client/review/page/snug.tsx
+++ b/client/review/page/snug.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import styled from "styled-components";
+import { Sidebar } from "../components/sidebar";
+import { SnugHeader } from "../components/snug-header";
+import { MessageSection } from "../components/message-section";
+
+const SnugWrapper = styled.section`
+  width: inherit;
+  height: inherit;
+  display: flex;
+  flex-direction: column;
+`;
+
+const ViewWrapper = styled.section`
+  height: 100%;
+  display: flex;
+`;
+
+export const Snug: React.FC = () => {
+  return (
+    <SnugWrapper>
+      <SnugHeader></SnugHeader>
+      <ViewWrapper>
+        <Sidebar></Sidebar>
+        <MessageSection></MessageSection>
+      </ViewWrapper>
+    </SnugWrapper>
+  );
+};


### PR DESCRIPTION
아직 로직은 없지만 선정했습니다.

**환경**
create-react-app --typescript 로 만들었습니다.
Reactjs, Typescript

**이미지**
<img width="1680" alt="스크린샷 2019-11-15 오전 10 30 08" src="https://user-images.githubusercontent.com/44811887/68909818-ebbeef80-0792-11ea-9449-8e12dccaeae2.png">

**내용**
- 노란색과 녹색, 회색의 컴포넌트는 높이가 고정 되어있습니다.
- 빨간색 컴포넌트는 너비가 고정되어있습니다.

**질문**
- flex를 이용해서 어떻게든 레이아웃을 짰는데 더 좋은 방법이 존재할까요?
- 코드 스타일과 React component를 만들 때 좋은 방법들을 리뷰를 통해 알려주셨으면 좋겠습니다. 


