### PR TITLE
@context/services/index.tsx 에서 ChannelService 를 임포트하지 못하는 이슈 해결

### DIFF
--- a/client/src/@context/services/index.tsx
+++ b/client/src/@context/services/index.tsx
@@ -1,5 +1,5 @@
 import {RepositoryDependencies} from "@context/repositories/index";
-import {ChannelService} from "core/service/channel-service.js";
+import {ChannelService} from "core/service/channel-service";
 
 export class ServiceDependencies {
   private readonly channelService: ChannelService;


### PR DESCRIPTION
### 해결 방안

- ChannelService 대한 import 경로에서 .js 확장자를 제거한다.

### 관련된 이슈

> #33 