### PR TITLE
[이상원] w3_리뷰요청_채널 목록 확인 모달 작성

### DIFF
--- a/review/src/contexts/channel-context.tsx
+++ b/review/src/contexts/channel-context.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, Dispatch, useReducer, useContext } from "react";
+
+export type Channel = {
+  [propName: string]: any;
+  title: string;
+  description: string;
+  privacy: boolean;
+  user?: string;
+  createdAt?: Date;
+  users?: string[];
+};
+
+export type Action = {
+  type: "CREATE";
+  title: string;
+  description: string;
+  privacy: boolean;
+  user?: string;
+  createdAt?: Date;
+};
+
+export type Channels = Channel[];
+
+type ChannelDispatch = Dispatch<Action>;
+
+const ChannelsStateContext = createContext<Channels | undefined>(undefined);
+
+const ChannelDispatchContext = createContext<ChannelDispatch | undefined>(
+  undefined
+);
+
+const channelsReducer = (state: Channels, action: Action): Channels => {
+  switch (action.type) {
+    case "CREATE":
+      return state.concat({
+        title: action.title,
+        description: action.description,
+        privacy: action.privacy,
+        user: action.user,
+        createdAt: action.createdAt
+      });
+  }
+};
+
+export const ChannelsProvider = ({
+  children
+}: {
+  children: React.ReactNode;
+}) => {
+  const [channels, dispatch] = useReducer(channelsReducer, []);
+  return (
+    <ChannelDispatchContext.Provider value={dispatch}>
+      <ChannelsStateContext.Provider value={channels}>
+        {children}
+      </ChannelsStateContext.Provider>
+    </ChannelDispatchContext.Provider>
+  );
+};
+
+export const useChannels = () => {
+  const state = useContext(ChannelsStateContext);
+  if (!state) return null;
+  return state;
+};
+
+export const useChannelDispatch = () => {
+  let dispatch = useContext(ChannelDispatchContext);
+  if (!dispatch) return null;
+  return dispatch;
+};

--- a/review/src/contexts/modal-context.tsx
+++ b/review/src/contexts/modal-context.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, Dispatch, useReducer, useContext } from "react";
+
+// 추후 모달들 타입을 여기에 추가
+type ModalToggled = {
+  ChannelPlusModal: boolean;
+  ChannelBrowseModal: boolean;
+};
+
+export type Action =
+  | {
+      type: "TOGGLE_CHANNEL_PLUS_MODAL";
+    }
+  | {
+      type: "TOGGLE_CHANNEL_BROWSE_MODAL";
+    };
+
+type ModalDispatch = Dispatch<Action>;
+
+const ModalStateContext = createContext<ModalToggled | undefined>(undefined);
+
+const ModalDispatchContext = createContext<ModalDispatch | undefined>(
+  undefined
+);
+
+const modalToggledReducer = (
+  state: ModalToggled,
+  action: Action
+): ModalToggled => {
+  switch (action.type) {
+    case "TOGGLE_CHANNEL_PLUS_MODAL":
+      return {
+        ...state,
+        ChannelPlusModal: !state.ChannelPlusModal
+      };
+    case "TOGGLE_CHANNEL_BROWSE_MODAL":
+      return {
+        ...state,
+        ChannelBrowseModal: !state.ChannelBrowseModal
+      };
+    default:
+      return {
+        ...state
+      };
+  }
+};
+
+export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
+  const [modalToggled, dispatch] = useReducer(modalToggledReducer, {
+    ChannelPlusModal: false,
+    ChannelBrowseModal: false
+  });
+  return (
+    <ModalDispatchContext.Provider value={dispatch}>
+      <ModalStateContext.Provider value={modalToggled}>
+        {children}
+      </ModalStateContext.Provider>
+    </ModalDispatchContext.Provider>
+  );
+};
+
+export const useModalToggled = () => {
+  const state = useContext(ModalStateContext);
+  if (!state) return null;
+  return state;
+};
+
+export const useModalToggledDispatch = () => {
+  const dispatch = useContext(ModalDispatchContext);
+  if (!dispatch) return null;
+  return dispatch;
+};

--- a/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-dropdown.tsx
+++ b/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-dropdown.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import styled from "styled-components";
+import { DisplayType, SortType } from "./index";
+import { CustomDropDown } from "presentation/components/atomic-reusable/custom-drop-down";
+
+const Wrapper = styled.section`
+  display: flex;
+`;
+
+const MarginBoxDropDown = styled.section`
+  width: 10%;
+  height: 100%;
+`;
+
+interface PropTypes {
+  setSelectedDisplayType(parameter: any | void): any | void;
+  setSelectedSortType(parameter: any | void): any | void;
+}
+
+export const ChannelBrowseModalDropdown: React.FC<PropTypes> = ({
+  setSelectedDisplayType,
+  setSelectedSortType
+}) => {
+  return (
+    <Wrapper>
+      <CustomDropDown
+        list={Object.values(DisplayType)}
+        type={"목록"}
+        setSelected={setSelectedDisplayType}
+      />
+      <MarginBoxDropDown />
+      <CustomDropDown
+        list={Object.values(SortType)}
+        type={"분류"}
+        setSelected={setSelectedSortType}
+      />
+    </Wrapper>
+  );
+};

--- a/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-header.tsx
+++ b/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-header.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import styled from "styled-components";
+import { useModalToggledDispatch } from "contexts/modal-context";
+import { CustomButton } from "presentation/components/atomic-reusable/custom-button";
+
+const Header = styled.header`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const Title = styled.section`
+  font-weight: solid;
+  font-size: 2rem;
+  width: 100%;
+`;
+
+export const ChannelBrowseModalHeader: React.FC = () => {
+  const dispatch = useModalToggledDispatch();
+
+  const clickHandler = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    dispatch &&
+      dispatch({
+        type: "TOGGLE_CHANNEL_BROWSE_MODAL"
+      });
+    dispatch &&
+      dispatch({
+        type: "TOGGLE_CHANNEL_PLUS_MODAL"
+      });
+  };
+
+  return (
+    <Header>
+      <Title>채널 목록</Title>
+      <CustomButton
+        color={"#148567"}
+        fontColor={"#ffffff"}
+        name={"채널 생성하기"}
+        size={"big"}
+        fontWeight={"bold"}
+        fontSize={"0.9rem"}
+        onClick={clickHandler}
+      />
+    </Header>
+  );
+};

--- a/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-information.tsx
+++ b/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-information.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import styled from "styled-components";
+import LetterXWhite from "assets/letter-x-white.png";
+import { IconBox } from "presentation/components/atomic-reusable/icon-box";
+
+const InformationSection = styled.section`
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+`;
+
+const InformationSectionHeader = styled.header`
+  width: 100%;
+  font-size: 1rem;
+`;
+
+interface PropTypes {
+  onClick(parameter: any | void): any | void;
+}
+
+export const ChannelBrowseModalInformation: React.FC<PropTypes> = ({
+  onClick
+}) => {
+  return (
+    <InformationSection>
+      <InformationSectionHeader>채널에 대하여</InformationSectionHeader>
+      <IconBox imageSrc={LetterXWhite} onClick={onClick} />
+    </InformationSection>
+  );
+};

--- a/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-item.tsx
+++ b/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-item.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import styled from "styled-components";
+
+const Wrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid white;
+  margin-top: 5px;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const Header = styled.header`
+  color: #ffffff;
+  font-weight: bold;
+`;
+
+const Contents = styled.article`
+  color: #ffffff;
+  font-size: 0.9rem;
+`;
+
+const Footer = styled.footer`
+  font-size: 0.7rem;
+`;
+
+interface ChannelBrowseModal {
+  title?: string;
+  description?: string;
+  privacy?: boolean;
+  user?: string;
+  createdAt?: Date;
+}
+
+export const ChannelBrowseModalItem: React.FC<ChannelBrowseModal> = props => {
+  return (
+    <Wrapper>
+      <Header>{props.title}</Header>
+      <Contents>{props.description}</Contents>
+      <Footer>
+        Created by {props.user} on{" "}
+        {props.createdAt && props.createdAt.toLocaleString()}
+      </Footer>
+    </Wrapper>
+  );
+};

--- a/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-sort-list.tsx
+++ b/review/src/presentation/snug/channel-browse-modal/channel-browse-modal-sort-list.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { DisplayType, SortType } from "./index";
+import { useChannels, Channel, Channels } from "contexts/channel-context";
+import { ChannelBrowseModalItem } from "./channel-browse-modal-item";
+
+interface Criterion {
+  DisplayType: DisplayType;
+  SortType: SortType;
+}
+
+const compareChannels = (channelA: any, channelB: any) => {
+  if (Object.prototype.toString.call(channelA) === "[object Date]") {
+    return channelA.getTime() < channelB.getTime()
+      ? -1
+      : channelA.getTime() > channelB.getTime()
+      ? 1
+      : 0;
+  }
+  return channelA < channelB ? -1 : channelA > channelB ? 1 : 0;
+};
+
+const returnSortedChannels = (channels: Channels, target: string) => {
+  return channels.sort((channelA: Channel, channelB: Channel) => {
+    return compareChannels(channelA[target], channelB[target]);
+  });
+};
+
+const sortBySortType = (channels: Channels, sortType: SortType) => {
+  switch (sortType) {
+    case SortType.title:
+      return returnSortedChannels(channels, "title");
+    case SortType.createdAt:
+      return returnSortedChannels(channels, "createdAt");
+
+    //todo : null을 대체할 적절한 반환형 생각하기
+    default:
+      return null;
+  }
+};
+
+const filterPrivateChannels = (channels: Channels, props: DisplayType) => {
+  if (props === DisplayType.private) {
+    return channels.filter(channel => {
+      return channel.privacy;
+    });
+  }
+  return null;
+};
+
+export const ChannelBrowseModalSortList: React.FC<Criterion> = props => {
+  const channels = useChannels();
+
+  const sortChannels = () => {
+    if (!channels) {
+      return null;
+    }
+
+    const privateChannels = filterPrivateChannels(channels, props.DisplayType);
+
+    const targetChannels = privateChannels ? privateChannels : channels;
+    return sortBySortType(targetChannels, props.SortType);
+  };
+
+  return (
+    <>
+      {channels &&
+        sortChannels()!.map(channel => {
+          return (
+            <ChannelBrowseModalItem
+              key={channel.title}
+              title={channel.title}
+              description={channel.description}
+              privacy={channel.privacy}
+              user={channel.user}
+              createdAt={channel.createdAt}
+            />
+          );
+        })}
+    </>
+  );
+};

--- a/review/src/presentation/snug/channel-browse-modal/index.tsx
+++ b/review/src/presentation/snug/channel-browse-modal/index.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useModalToggledDispatch } from "contexts/modal-context";
+import { CustomModal } from "presentation/components/atomic-reusable/custom-modal";
+import { ChannelBrowseModalSortList } from "./channel-browse-modal-sort-list";
+import { ChannelBrowseModalDropdown } from "./channel-browse-modal-dropdown";
+import { ChannelBrowseModalHeader } from "./channel-browse-modal-header";
+import { ChannelBrowseModalInformation } from "./channel-browse-modal-information";
+
+const MarginBox = styled.section`
+  width: 30%;
+  height: 100%;
+`;
+
+const Content = styled.section`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export enum DisplayType {
+  "all" = "전체보기",
+  "private" = "비밀 채널만 보기"
+}
+
+export enum SortType {
+  "title" = "채널 이름 순",
+  "createdAt" = "만든 날짜 순",
+  "userLarge" = "사람 많은 순",
+  "userSmall" = "사람 적은 순"
+}
+
+// todo : 해당 section뿐만 아니라 전역적으로 keydown 이벤트가 적용될 수 있도록 함수 위치 변경
+export const ChannelBrowseModal: React.FC = () => {
+  const [selectedDisplayType, setSelectedDisplayType] = useState(
+    DisplayType.all
+  );
+  const [selectedSortType, setSelectedSortType] = useState(SortType.title);
+
+  const dispatch = useModalToggledDispatch();
+
+  const toggleChannelBrowseModal = () => {
+    dispatch &&
+      dispatch({
+        type: "TOGGLE_CHANNEL_BROWSE_MODAL"
+      });
+  };
+
+  const clickHandler = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+    toggleChannelBrowseModal();
+  };
+
+  const keyDownHandler = (event: React.KeyboardEvent<HTMLElement>) => {
+    toggleChannelBrowseModal();
+  };
+
+  return (
+    <CustomModal>
+      <MarginBox />
+      <Content tabIndex={-1} onKeyDown={keyDownHandler}>
+        <ChannelBrowseModalInformation onClick={clickHandler} />
+        <ChannelBrowseModalHeader />
+        <ChannelBrowseModalDropdown
+          setSelectedDisplayType={setSelectedDisplayType}
+          setSelectedSortType={setSelectedSortType}
+        />
+        <ChannelBrowseModalSortList
+          DisplayType={selectedDisplayType}
+          SortType={selectedSortType}
+        />
+      </Content>
+      <MarginBox />
+    </CustomModal>
+  );
+};


### PR DESCRIPTION
## Related Issue

>  example Fixes #issue_number

## Description and Motivation
 - 생성된 채널 목록을 확인하는 모달을 만들었습니다.
 - 채널 목록을 클릭하면 위에서 만든 모달이 화면 전체에 나타납니다.  
 - 모달 속 X 버튼이나 esc를 누르면 모달이 닫힌다.
 - 모달의 채널 생성하기 버튼을 클릭하면 채널 목록 모달이 닫히고 채널 생성 모달이 열린다. 
 - 특정 조건에 맞는 채널 목록을 확인할 수 있습니다. 

- 프로젝트에서 쓰는 모달을 한 곳에서 관리하고 싶었습니다.
 - 사용자로 하여금 이미 익숙한 모달 제어 방법인 esc키로 모달을 제어하는 방법을 제공하고 싶었습니다. 
 - 사용자가 원하는 조건을 적용시킨(filtering) 채널 목록을 제공하고 싶었습니다.

## 질문
 1. Typescript에서 **함수 자체를 인자로 넘겨줄 때  type을 지정하는 방식에 대하여 질문** 드립니다. 

어떤 함수가 **타입을 구애받지 않는 type**을 **인자로 하나 받거나 아니면 아예 받지 않는 방식을 표현**하기 위하여, **(any | void) : any | void** 라고 함수 type을 지정하면, 예시처럼 void 는 함수의 인자나 반환값 타입에 포함되지 않습니다. 

공식문서를 찾아보니, any와 void는 반대 개념으로, Typescript에서 쓰는 것 같습니다. 그렇다면 함수 타입을 어떻게 지정하면 될까요? 

```javascript
// 예시
interface PropTypes {
  onClick(parameter: any | void): any | void;
}
```
 
 2. Typescript에서 함수의 반환값을 설정할 때, **'없다' 혹은 '실패'** 라는 방식을 표현하기 위해서 **<리턴 하고 싶은 타입 | boolean>을 쓰는 방식이 적절한 지 질문**하고 싶습니다. 

함수의 반환값이 Object 인 경우, null 이 아닌 boolean false을 리턴하는 것이 적절한 지 질문하고 싶습니다. 


```javascript
// 예시
  async getList(channel: Channel): Promise<Post[] | boolean> {
     // ...
  }
```



## 이미지 예시
![image](https://user-images.githubusercontent.com/47213425/69217827-d42ca000-0bb2-11ea-9581-ad0bb0085cab.png)
![image](https://user-images.githubusercontent.com/47213425/69217836-d989ea80-0bb2-11ea-9d30-a611e8e8bf4c.png)
![image](https://user-images.githubusercontent.com/47213425/69217844-ddb60800-0bb2-11ea-8c34-3c70b6709b8c.png)

## Types of changes

- [ ] Docs change
- [ ] dependency upgrade
- [ ] refactoring
- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Review

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.