### PR TITLE
[이상원] w4_리뷰요청_migration 설정 리뷰 요청

### DIFF
--- a/review/1574745011724-ADD-PROFILE.ts
+++ b/review/1574745011724-ADD-PROFILE.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ADDPROFILE1574745011724 implements MigrationInterface {
+    name = 'ADDPROFILE1574745011724'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE TABLE `profile` (`id` int NOT NULL AUTO_INCREMENT, `name` varchar(255) NOT NULL, `status` varchar(255) NOT NULL, `thumbnail` varchar(255) NULL, `description` varchar(255) NULL, `role` enum ('admin', 'member') NOT NULL, `createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`)) ENGINE=InnoDB", undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("DROP TABLE `profile`", undefined);
+    }
+
+}

--- a/review/1574745035521-ADD-ROOM.ts
+++ b/review/1574745035521-ADD-ROOM.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ADDROOM1574745035521 implements MigrationInterface {
+  name = "ADDROOM1574745035521";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      "CREATE TABLE `room` (`id` int NOT NULL AUTO_INCREMENT,`title` varchar(255) NOT NULL, `description` varchar(255) NULL, `isPrivate` tinyint NOT NULL, `isChannel` tinyint NOT NULL, `createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `profileId` int NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` ADD CONSTRAINT `FK_852a48541632bfb2004705858a7` FOREIGN KEY (`profileId`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      "ALTER TABLE `room` DROP FOREIGN KEY `FK_852a48541632bfb2004705858a7`",
+      undefined
+    );
+    await queryRunner.query("DROP TABLE `room`", undefined);
+    await queryRunner.query("DROP TABLE `profile`", undefined);
+  }
+}

--- a/review/1574745189357-ADD-POST.ts
+++ b/review/1574745189357-ADD-POST.ts
@@ -1,0 +1,20 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ADDPOST1574745189357 implements MigrationInterface {
+    name = 'ADDPOST1574745189357'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE TABLE `post` (`id` int NOT NULL AUTO_INCREMENT, `contents` varchar(255) NULL, `imgSrc` varchar(255) NULL, `createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `profileId` int NULL, `roomId` int NULL, `parentCategoryId` int NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB", undefined);
+        await queryRunner.query("ALTER TABLE `post` ADD CONSTRAINT `FK_970844fcd10c2b6df7c1b49eacf` FOREIGN KEY (`profileId`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+        await queryRunner.query("ALTER TABLE `post` ADD CONSTRAINT `FK_451a4a7489ef7889aa6b243c884` FOREIGN KEY (`roomId`) REFERENCES `room`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+        await queryRunner.query("ALTER TABLE `post` ADD CONSTRAINT `FK_536cdbad512a2fd8bd7b9970b35` FOREIGN KEY (`parentCategoryId`) REFERENCES `post`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("ALTER TABLE `post` DROP FOREIGN KEY `FK_536cdbad512a2fd8bd7b9970b35`", undefined);
+        await queryRunner.query("ALTER TABLE `post` DROP FOREIGN KEY `FK_451a4a7489ef7889aa6b243c884`", undefined);
+        await queryRunner.query("ALTER TABLE `post` DROP FOREIGN KEY `FK_970844fcd10c2b6df7c1b49eacf`", undefined);
+        await queryRunner.query("DROP TABLE `post`", undefined);
+    }
+
+}

--- a/review/1574746206264-ADD-SNUG.ts
+++ b/review/1574746206264-ADD-SNUG.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ADDSNUG1574746206264 implements MigrationInterface {
+    name = 'ADDSNUG1574746206264'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE TABLE `snug` (`id` int NOT NULL AUTO_INCREMENT, `name` varchar(255) NOT NULL, `thumbnail` tinyint NULL, `description` tinyint NULL, `createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`)) ENGINE=InnoDB", undefined);
+        await queryRunner.query("ALTER TABLE `profile` ADD `snugId` int NULL", undefined);
+        await queryRunner.query("ALTER TABLE `room` ADD `snugId` int NULL", undefined);
+        await queryRunner.query("ALTER TABLE `profile` ADD CONSTRAINT `FK_f9f76d1aa45cde8b687d9592aa6` FOREIGN KEY (`snugId`) REFERENCES `snug`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+        await queryRunner.query("ALTER TABLE `room` ADD CONSTRAINT `FK_3e828c113f00fcf6aac1b338935` FOREIGN KEY (`snugId`) REFERENCES `snug`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("ALTER TABLE `room` DROP FOREIGN KEY `FK_3e828c113f00fcf6aac1b338935`", undefined);
+        await queryRunner.query("ALTER TABLE `profile` DROP FOREIGN KEY `FK_f9f76d1aa45cde8b687d9592aa6`", undefined);
+        await queryRunner.query("ALTER TABLE `room` DROP COLUMN `snugId`", undefined);
+        await queryRunner.query("ALTER TABLE `profile` DROP COLUMN `snugId`", undefined);
+        await queryRunner.query("DROP TABLE `snug`", undefined);
+    }
+
+}

--- a/review/1574746492050-ADD-USER.ts
+++ b/review/1574746492050-ADD-USER.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ADDUSER1574746492050 implements MigrationInterface {
+  name = "ADDUSER1574746492050";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query("ALTER TABLE `profile` ADD `userId` int NOT NULL");
+    await queryRunner.query(
+      "CREATE TABLE `user` (`id` int NOT NULL AUTO_INCREMENT, `email` varchar(255) NOT NULL, `password` varchar(255) NOT NULL, `createdAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updatedAt` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`)) ENGINE=InnoDB",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` ADD CONSTRAINT `FK_a24972ebd73b106250713dcddd9` FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      "ALTER TABLE `post` DROP FOREIGN KEY `FK_536cdbad512a2fd8bd7b9970b35`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `post` DROP FOREIGN KEY `FK_451a4a7489ef7889aa6b243c884`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `post` DROP FOREIGN KEY `FK_970844fcd10c2b6df7c1b49eacf`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` DROP FOREIGN KEY `FK_3e828c113f00fcf6aac1b338935`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` DROP FOREIGN KEY `FK_852a48541632bfb2004705858a7`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` DROP FOREIGN KEY `FK_a24972ebd73b106250713dcddd9`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` DROP FOREIGN KEY `FK_f9f76d1aa45cde8b687d9592aa6`",
+      undefined
+    );
+    await queryRunner.query("DROP TABLE `post`", undefined);
+    await queryRunner.query("DROP TABLE `room`", undefined);
+    await queryRunner.query("DROP TABLE `profile`", undefined);
+    await queryRunner.query("DROP TABLE `user`", undefined);
+    await queryRunner.query("DROP TABLE `snug`", undefined);
+  }
+}

--- a/review/1574748267870-ADD-PARTICIPATEIN.ts
+++ b/review/1574748267870-ADD-PARTICIPATEIN.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class ADDPARTICIPATEIN1574748267870 implements MigrationInterface {
+    name = 'ADDPARTICIPATEIN1574748267870'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("CREATE TABLE `participate_in` (`id` int NOT NULL AUTO_INCREMENT, `profileId` int NULL, `roomId` int NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB", undefined);
+        await queryRunner.query("ALTER TABLE `participate_in` ADD CONSTRAINT `FK_e6071173fadf8584df5b0463123` FOREIGN KEY (`profileId`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+        await queryRunner.query("ALTER TABLE `participate_in` ADD CONSTRAINT `FK_51d995a68f7079b9c89fd1d1c19` FOREIGN KEY (`roomId`) REFERENCES `room`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION", undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("ALTER TABLE `participate_in` DROP FOREIGN KEY `FK_51d995a68f7079b9c89fd1d1c19`", undefined);
+        await queryRunner.query("ALTER TABLE `participate_in` DROP FOREIGN KEY `FK_e6071173fadf8584df5b0463123`", undefined);
+        await queryRunner.query("DROP TABLE `participate_in`", undefined);
+    }
+
+}

--- a/review/1574749093761-CHANGE-NAME.ts
+++ b/review/1574749093761-CHANGE-NAME.ts
@@ -1,0 +1,83 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CHANGENAME1574749093761 implements MigrationInterface {
+  name = "CHANGENAME1574749093761";
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      "ALTER TABLE `room` DROP FOREIGN KEY `FK_852a48541632bfb2004705858a7`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `participate_in` DROP FOREIGN KEY `FK_e6071173fadf8584df5b0463123`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` CHANGE `profileId` `creator` int NULL",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `participate_in` CHANGE `profileId` `participant` int NULL",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` DROP FOREIGN KEY `FK_a24972ebd73b106250713dcddd9`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` CHANGE `userId` `userId` int NULL",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` ADD CONSTRAINT `FK_a24972ebd73b106250713dcddd9` FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` ADD CONSTRAINT `FK_86e40e0afb08286884be0e6f38c` FOREIGN KEY (`creator`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `participate_in` ADD CONSTRAINT `FK_d914b8226336ece30658108e80e` FOREIGN KEY (`participant`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      "ALTER TABLE `participate_in` DROP FOREIGN KEY `FK_d914b8226336ece30658108e80e`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` DROP FOREIGN KEY `FK_86e40e0afb08286884be0e6f38c`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` DROP FOREIGN KEY `FK_a24972ebd73b106250713dcddd9`",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` CHANGE `userId` `userId` int NOT NULL",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `profile` ADD CONSTRAINT `FK_a24972ebd73b106250713dcddd9` FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `participate_in` CHANGE `participantId` `profileId` int NULL",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` CHANGE `creatorId` `profileId` int NULL",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `participate_in` ADD CONSTRAINT `FK_e6071173fadf8584df5b0463123` FOREIGN KEY (`profileId`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+    await queryRunner.query(
+      "ALTER TABLE `room` ADD CONSTRAINT `FK_852a48541632bfb2004705858a7` FOREIGN KEY (`profileId`) REFERENCES `profile`(`id`) ON DELETE NO ACTION ON UPDATE NO ACTION",
+      undefined
+    );
+  }
+}

--- a/review/Base.ts
+++ b/review/Base.ts
@@ -1,0 +1,8 @@
+import {BaseEntity, CreateDateColumn, UpdateDateColumn} from "typeorm";
+
+export class Base extends BaseEntity {
+  @CreateDateColumn()
+  createdAt: Date;
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/review/ParticipateIn.ts
+++ b/review/ParticipateIn.ts
@@ -1,0 +1,15 @@
+import { BaseEntity, Entity, PrimaryGeneratedColumn, ManyToOne } from "typeorm";
+import { Profile } from "./Profile";
+import { Room } from "./Room";
+
+@Entity()
+export class ParticipateIn extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(type => Profile)
+  participant: Profile;
+
+  @ManyToOne(type => Room)
+  room: Room;
+}

--- a/review/Post.ts
+++ b/review/Post.ts
@@ -1,0 +1,32 @@
+import {Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn} from "typeorm";
+import {Profile} from "./Profile";
+import {Room} from "./Room";
+import {Base} from "./Base";
+
+@Entity()
+export class Post extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+  @Column({nullable: true})
+  contents: string;
+  @Column({nullable: true})
+  imgSrc: string;
+  @ManyToOne(type => Profile, {eager: true})
+  profile: Profile;
+  @ManyToOne(type => Room)
+  room: Room;
+  @ManyToOne(
+          type => Post,
+          post => post.childCategories
+  )
+  parentCategory: Post;
+  @OneToMany(
+          type => Post,
+          post => post.parentCategory
+  )
+  childCategories: Post[];
+
+  static findByChannelId(id: string, pageable: object): Promise<Post[]> {
+    return this.find({where: {room: id}, ...pageable});
+  }
+}

--- a/review/Profile.ts
+++ b/review/Profile.ts
@@ -1,0 +1,36 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import {Snug} from "./Snug";
+import {User} from "./User";
+import {Base} from "./Base";
+
+export type UserRoleType = "admin" | "participant";
+
+@Entity()
+export class Profile extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  status: string;
+
+  @Column({ nullable: true })
+  thumbnail: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({
+    type: "enum",
+    enum: ["admin", "member"]
+  })
+  role: UserRoleType;
+
+  @ManyToOne(type => Snug)
+  snug: Snug;
+
+  @ManyToOne(type => User)
+  user: User;
+}

--- a/review/Room.ts
+++ b/review/Room.ts
@@ -1,0 +1,32 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import {Profile} from "./Profile";
+import {Snug} from "./Snug";
+import {Base} from "./Base";
+
+@Entity()
+export class Room extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column()
+  isPrivate: boolean;
+
+  @Column()
+  isChannel: boolean;
+
+  @ManyToOne(type => Profile)
+  creator: Profile;
+
+  @ManyToOne(type => Snug)
+  snug: Snug;
+
+  static findByTitle(title: string): Promise<Room> {
+    return Room.findOne({where: {title: title}});
+  }
+}

--- a/review/Snug.ts
+++ b/review/Snug.ts
@@ -1,0 +1,17 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "typeorm";
+import {Base} from "./Base";
+
+@Entity()
+export class Snug extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  thumbnail: boolean;
+
+  @Column({ nullable: true })
+  description: boolean;
+}

--- a/review/User.ts
+++ b/review/User.ts
@@ -1,0 +1,14 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "typeorm";
+import {Base} from "./Base";
+
+@Entity()
+export class User extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  email: string;
+
+  @Column()
+  password: string;
+}


### PR DESCRIPTION
why : Migration에 Entity에 옵션 관련 리뷰을 받기 위하여 저장.

## Related Issue

>  example Fixes #issue_number

## Description and Motivation
- 팀원들이 개발할 때, 모두 동일한 데이터베이스를 가지고 시작하기를 원했습니다.
- 더불어, 향후 typeorm을 활용할 때, 조금 더 entity들을 편하게 사용할 수 있도록 관계를 맺었습니다.

## 질문
- entity들 다 대 일 관계를 설정할 때 @ManyToOne만을 이용하여 관계를 설정했는데, 반대로 @OneToMany를 설정하는 일이 필수인지 궁금합니다.
- react rendering 최적화는 어느 기준으로, 언제 시행해야 하는지 궁금합니다.


## Types of changes

- [ ] Docs change
- [ ] dependency upgrade
- [ ] refactoring
- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Review

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.