### PR TITLE
초대할 Email 리스트를 API 서버에 전송하는 기능 추가

### DIFF
--- a/client/src/@context/http-providers/http-providers.tsx
+++ b/client/src/@context/http-providers/http-providers.tsx
@@ -7,7 +7,6 @@ export class HttpProviderDependencies {
   private readonly channel: ChannelApi;
   private readonly post: PostApi;
   private readonly invite: InviteApi;
-
   private readonly axiosWrapper: AxiosWrapper;
 
   constructor() {

--- a/client/src/@context/http-providers/http-providers.tsx
+++ b/client/src/@context/http-providers/http-providers.tsx
@@ -1,16 +1,20 @@
 import { ChannelApi } from "data/http/api/channel-api";
 import { AxiosWrapper } from "data/http/api/axios-wrapper";
 import { PostApi } from "data/http/api/post-api";
+import {InviteApi} from "data/http/api/invite-api";
 
 export class HttpProviderDependencies {
   private readonly channel: ChannelApi;
   private readonly post: PostApi;
+  private readonly invite: InviteApi;
+
   private readonly axiosWrapper: AxiosWrapper;
 
   constructor() {
     this.axiosWrapper = new AxiosWrapper();
     this.channel = new ChannelApi(this.axiosWrapper);
     this.post = new PostApi(this.axiosWrapper);
+    this.invite = new InviteApi(this.axiosWrapper);
   }
 
   getChannel(): ChannelApi {
@@ -19,5 +23,9 @@ export class HttpProviderDependencies {
 
   getPost(): PostApi {
     return this.post;
+  }
+
+  getInvite(): InviteApi {
+    return this.invite;
   }
 }

--- a/client/src/@context/repositories/index.tsx
+++ b/client/src/@context/repositories/index.tsx
@@ -1,11 +1,13 @@
 import { StorageProviderDependencies } from "@context/storage-providers/storage-providers";
 import { HttpProviderDependencies } from "@context/http-providers/http-providers";
+import { InviteRepositoryDependency } from "@context/repositories/invite";
 import { ChatRoomRepositoryDependency } from "./chat-room";
 import { PostingRepositoryDependency } from "./posting";
 
 export class RepositoryDependencies {
   private readonly chatRoom: ChatRoomRepositoryDependency;
   private readonly posting: PostingRepositoryDependency;
+  private readonly invite: InviteRepositoryDependency;
 
   constructor(
     apies: HttpProviderDependencies,
@@ -13,6 +15,7 @@ export class RepositoryDependencies {
   ) {
     this.chatRoom = new ChatRoomRepositoryDependency(apies.getChannel());
     this.posting = new PostingRepositoryDependency(apies.getPost());
+    this.invite = new InviteRepositoryDependency(apies.getInvite());
   }
 
   getChatRoom() {
@@ -21,5 +24,9 @@ export class RepositoryDependencies {
 
   getPosting() {
     return this.posting;
+  }
+
+  getInvite() {
+    return this.invite;
   }
 }

--- a/client/src/@context/repositories/invite.ts
+++ b/client/src/@context/repositories/invite.ts
@@ -1,0 +1,15 @@
+import {InviteRepositoryType} from "core/use-case/invite-repository-type";
+import {InviteApi} from "data/http/api/invite-api";
+import {InviteRepository} from "data/repository/invite-repository";
+
+export class InviteRepositoryDependency {
+  private readonly inviteRepository: InviteRepositoryType;
+
+  constructor(api: InviteApi) {
+    this.inviteRepository = new InviteRepository(api);
+  }
+
+  getInviteRepository(): InviteRepositoryType {
+    return this.inviteRepository;
+  }
+}

--- a/client/src/@context/services/index.tsx
+++ b/client/src/@context/services/index.tsx
@@ -1,10 +1,12 @@
 import { RepositoryDependencies } from "@context/repositories/index";
 import { ChannelService } from "core/service/channel-service";
 import { PostService } from "core/service/post-service";
+import {InviteService} from "core/service/invite-service";
 
 export class ServiceDependencies {
   readonly channelService: ChannelService;
   readonly postService: PostService;
+  readonly inviteService: InviteService;
 
   constructor(repositories: RepositoryDependencies) {
     this.channelService = new ChannelService(
@@ -12,6 +14,9 @@ export class ServiceDependencies {
     );
     this.postService = new PostService(
       repositories.getPosting().getPostRepository()
+    );
+    this.inviteService = new InviteService(
+            repositories.getInvite().getInviteRepository()
     );
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -65,7 +65,7 @@ const App: React.FC = () => {
       ></Route>
       <Route
         exact
-        path="/invite-users"
+        path="/invite-users/:snugId"
         component={(props: any) => (
           <InviteUsers {...props} Application={Application} />
         )}

--- a/client/src/core/model/email-model.ts
+++ b/client/src/core/model/email-model.ts
@@ -26,4 +26,8 @@ export class EmailModel {
   public toString() {
     return this.localPart + EmailModel.DELIMITER + this.domain;
   }
+
+  public hasEmail() {
+    return this.localPart && this.domain;
+  }
 }

--- a/client/src/core/model/email-model.ts
+++ b/client/src/core/model/email-model.ts
@@ -22,4 +22,8 @@ export class EmailModel {
   public getId() {
     return this.id;
   }
+
+  public toString() {
+    return this.localPart + EmailModel.DELIMITER + this.domain;
+  }
 }

--- a/client/src/core/service/invite-service.ts
+++ b/client/src/core/service/invite-service.ts
@@ -1,0 +1,23 @@
+import {InviteRepositoryType} from "core/use-case/invite-repository-type";
+import {EmailModel} from "core/model/email-model";
+
+export class InviteService {
+  private repository: InviteRepositoryType;
+
+  constructor(inviteRepository: InviteRepositoryType) {
+    this.repository = inviteRepository;
+  }
+
+  async send(emailModels: EmailModel[]): Promise<boolean> {
+    try {
+      const emails = this.transferToString(emailModels);
+      return await this.repository.send(emails);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private transferToString(emails: EmailModel[]): string[] {
+    return emails.map(email => email.toString());
+  }
+}

--- a/client/src/core/service/invite-service.ts
+++ b/client/src/core/service/invite-service.ts
@@ -8,10 +8,10 @@ export class InviteService {
     this.repository = inviteRepository;
   }
 
-  async send(emailModels: EmailModel[]): Promise<boolean> {
+  async send(snugId: string, emailModels: EmailModel[]): Promise<boolean> {
     try {
       const emails = this.transferToString(emailModels);
-      return await this.repository.send(emails);
+      return await this.repository.send(snugId, emails);
     } catch (error) {
       return false;
     }

--- a/client/src/core/service/invite-service.ts
+++ b/client/src/core/service/invite-service.ts
@@ -18,6 +18,7 @@ export class InviteService {
   }
 
   private transferToString(emails: EmailModel[]): string[] {
-    return emails.map(email => email.toString());
+    return emails.filter(email => email.hasEmail())
+            .map(email => email.toString());
   }
 }

--- a/client/src/core/service/invite-service.ts
+++ b/client/src/core/service/invite-service.ts
@@ -8,6 +8,20 @@ export class InviteService {
     this.repository = inviteRepository;
   }
 
+  private addEmailIfNotDuplicated(emails: string[], email: string): string[] {
+    if(!emails.includes(email)) {
+      return emails.concat(email);
+    }
+
+    return emails;
+  }
+
+  private transferToString(emails: EmailModel[]): string[] {
+    return emails.filter(email => email.hasEmail())
+            .map(email => email.toString())
+            .reduce(this.addEmailIfNotDuplicated, []);
+  }
+
   async send(snugId: string, emailModels: EmailModel[]): Promise<boolean> {
     try {
       const emails = this.transferToString(emailModels);
@@ -15,10 +29,5 @@ export class InviteService {
     } catch (error) {
       return false;
     }
-  }
-
-  private transferToString(emails: EmailModel[]): string[] {
-    return emails.filter(email => email.hasEmail())
-            .map(email => email.toString());
   }
 }

--- a/client/src/core/use-case/invite-repository-type.ts
+++ b/client/src/core/use-case/invite-repository-type.ts
@@ -1,3 +1,3 @@
 export interface InviteRepositoryType {
-  send(emails: string[]): Promise<boolean>;
+  send(snugId: string, emails: string[]): Promise<boolean>;
 }

--- a/client/src/core/use-case/invite-repository-type.ts
+++ b/client/src/core/use-case/invite-repository-type.ts
@@ -1,0 +1,3 @@
+export interface InviteRepositoryType {
+  send(emails: string[]): Promise<boolean>;
+}

--- a/client/src/data/http/api/invite-api.ts
+++ b/client/src/data/http/api/invite-api.ts
@@ -11,9 +11,9 @@ export class InviteApi {
     this.axios = axios.getAxios();
   }
 
-  sendEmails(emails: string[]) {
+  sendEmails(snugId: string, emails: string[]) {
     return this.axios
-            .post(`/api/invite`, {emails})
+            .post(`/api/snug/${snugId}/invite`, {snugId, emails})
             .then((response: AxiosResponse<ResponseEntity<string[]>>) => StatusCodes.isOk(response.status))
             .catch((error: AxiosError) =>
                     AxiosErrorHandler.handleError(

--- a/client/src/data/http/api/invite-api.ts
+++ b/client/src/data/http/api/invite-api.ts
@@ -1,0 +1,25 @@
+import {AxiosWrapper} from "./axios-wrapper";
+import {AxiosError, AxiosResponse} from "axios";
+import {ResponseEntity} from "data/http/api/response/ResponseEntity";
+import {StatusCodes} from "data/http/api/status-codes";
+import {AxiosErrorHandler} from "data/http/api/axiosErrorHandler";
+
+export class InviteApi {
+  private axios: any;
+
+  constructor(axios: AxiosWrapper) {
+    this.axios = axios.getAxios();
+  }
+
+  sendEmails(emails: string[]) {
+    return this.axios
+            .post(`/api/invite`, {emails})
+            .then((response: AxiosResponse<ResponseEntity<string[]>>) => StatusCodes.isOk(response.status))
+            .catch((error: AxiosError) =>
+                    AxiosErrorHandler.handleError(
+                            error,
+                            `${emails!} 추가 과정에서 예기치 못한 에러가 발생했습니다.`
+                    )
+            );
+  }
+}

--- a/client/src/data/repository/invite-repository.ts
+++ b/client/src/data/repository/invite-repository.ts
@@ -1,0 +1,15 @@
+import {InviteRepositoryType} from "core/use-case/invite-repository-type";
+import {InviteApi} from "data/http/api/invite-api";
+
+export class InviteRepository implements InviteRepositoryType {
+  private readonly inviteApi: InviteApi;
+
+  constructor(inviteApi: InviteApi) {
+    this.inviteApi = inviteApi;
+  }
+
+  async send(emails: string[]): Promise<boolean> {
+    return await this.inviteApi.sendEmails(emails);
+  }
+
+}

--- a/client/src/data/repository/invite-repository.ts
+++ b/client/src/data/repository/invite-repository.ts
@@ -8,8 +8,8 @@ export class InviteRepository implements InviteRepositoryType {
     this.inviteApi = inviteApi;
   }
 
-  async send(emails: string[]): Promise<boolean> {
-    return await this.inviteApi.sendEmails(emails);
+  async send(snugId: string, emails: string[]): Promise<boolean> {
+    return await this.inviteApi.sendEmails(snugId, emails);
   }
 
 }

--- a/client/src/presentation/pages/invite-users/container/index.tsx
+++ b/client/src/presentation/pages/invite-users/container/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import {InviteDescription} from "presentation/pages/invite-users/description";
 import {InviteForm} from "presentation/pages/invite-users/form";
+import {ApplicationProptype} from "prop-types/application-type";
 
 const Wrapper = styled.section`
   background-color: #ffffff;
@@ -13,11 +14,11 @@ const Wrapper = styled.section`
 `;
 
 
-export const InviteUsersContainer: React.FC = () => {
+export const InviteUsersContainer: React.FC<ApplicationProptype> = ({Application}) => {
   return (
           <Wrapper>
             <InviteDescription/>
-            <InviteForm/>
+            <InviteForm Application = { Application } />
           </Wrapper>
   );
 };

--- a/client/src/presentation/pages/invite-users/container/index.tsx
+++ b/client/src/presentation/pages/invite-users/container/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import {InviteDescription} from "presentation/pages/invite-users/description";
 import {InviteForm} from "presentation/pages/invite-users/form";
-import {ApplicationProptype} from "prop-types/application-type";
+import {AppSocketInviteMatchProps} from "prop-types/match-extends-types";
 
 const Wrapper = styled.section`
   background-color: #ffffff;
@@ -14,11 +14,11 @@ const Wrapper = styled.section`
 `;
 
 
-export const InviteUsersContainer: React.FC<ApplicationProptype> = ({Application}) => {
+export const InviteUsersContainer: React.FC<AppSocketInviteMatchProps> = props => {
   return (
           <Wrapper>
             <InviteDescription/>
-            <InviteForm Application = { Application } />
+            <InviteForm {...props} />
           </Wrapper>
   );
 };

--- a/client/src/presentation/pages/invite-users/form/Invite-button.tsx
+++ b/client/src/presentation/pages/invite-users/form/Invite-button.tsx
@@ -1,31 +1,47 @@
 import React from "react";
 import styled from "styled-components";
 import {CustomButton} from "presentation/components/atomic-reusable/custom-button";
+import {History} from "history";
 
-const ButtonWrapper = styled.section`
-  width: 100%;
+const Wrapper = styled.section`
   display: flex;
   flex-direction: column;
-  align-items: center;
+`;
+
+const ButtonWrapper = styled.section`
+  flex: 1
   margin-top: 1rem;
 `;
 
 interface PropType {
-  onClick(parameter: any | void): any | void;
+  history: History<any>;
+  sendEmails(parameter: any | void): any | void;
 }
 
-export const InviteButton: React.FC<PropType> = ({onClick}) => {
+export const InviteButton: React.FC<PropType> = ({history, sendEmails}) => {
+  const goHome = () => history.push("/");
   return (
-          <ButtonWrapper>
-            <CustomButton
-                    color={"#148567"}
-                    fontColor={"#ffffff"}
-                    name={"초대하기"}
-                    size={"big"}
-                    fontWeight={"bold"}
-                    fontSize={"1.9rem"}
-                    onClick={onClick}
-            />
-          </ButtonWrapper>
+          <Wrapper>
+            <ButtonWrapper>
+              <CustomButton
+                      color={"#148567"}
+                      fontColor={"#ffffff"}
+                      name={"초대하기"}
+                      size={"100%"}
+                      fontSize={"1.9rem"}
+                      onClick={sendEmails}
+              />
+            </ButtonWrapper>
+            <ButtonWrapper>
+              <CustomButton
+                      color={"#148567"}
+                      fontColor={"#ffffff"}
+                      name={"다음"}
+                      size={"100%"}
+                      fontSize={"1.9rem"}
+                      onClick={goHome}
+              />
+            </ButtonWrapper>
+          </Wrapper>
   );
 };

--- a/client/src/presentation/pages/invite-users/form/Invite-button.tsx
+++ b/client/src/presentation/pages/invite-users/form/Invite-button.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import {CustomButton} from "presentation/components/atomic-reusable/custom-button";
-import {History} from "history";
 
 const Wrapper = styled.section`
   display: flex;
@@ -14,12 +13,15 @@ const ButtonWrapper = styled.section`
 `;
 
 interface PropType {
-  history: History<any>;
   sendEmails(parameter: any | void): any | void;
 }
 
-export const InviteButton: React.FC<PropType> = ({history, sendEmails}) => {
-  const goHome = () => history.push("/");
+export const InviteButton: React.FC<PropType> = ({sendEmails}) => {
+  const goHome = (event: React.MouseEvent) => {
+    event.preventDefault();
+    window.location.assign("/");
+  };
+
   return (
           <Wrapper>
             <ButtonWrapper>

--- a/client/src/presentation/pages/invite-users/form/index.tsx
+++ b/client/src/presentation/pages/invite-users/form/index.tsx
@@ -12,18 +12,18 @@ const Form = styled.form`
   width: 40%;
 `;
 
-export const InviteForm: React.FC<AppSocketInviteMatchProps> = ({match, history, Application}) => {
+export const InviteForm: React.FC<AppSocketInviteMatchProps> = ({match, Application}) => {
   const [emails, changeEmails] = useState<EmailModel[]>([]);
   if (!match.params.snugId) return null;
   const sendEmails = (event: React.MouseEvent) => {
     event.preventDefault();
     Application.services.inviteService.send(match.params.snugId, emails);
-    history.push("/");
+    window.location.assign("/");
   };
   return (
           <Form>
             <InviteUsers emails={emails} changeEmails={changeEmails}/>
-            <InviteButton history={history} sendEmails={sendEmails}/>
+            <InviteButton sendEmails={sendEmails}/>
           </Form>
   );
 };

--- a/client/src/presentation/pages/invite-users/form/index.tsx
+++ b/client/src/presentation/pages/invite-users/form/index.tsx
@@ -3,6 +3,7 @@ import React, {useState} from "react";
 import {InviteUsers} from "presentation/pages/invite-users/form/invite-users";
 import {InviteButton} from "presentation/pages/invite-users/form/Invite-button";
 import {EmailModel} from "core/model/email-model";
+import {ApplicationProptype} from "prop-types/application-type";
 
 const Form = styled.form`
   display: flex;
@@ -11,17 +12,18 @@ const Form = styled.form`
   width: 40%;
 `;
 
-export const InviteForm: React.FC = () => {
+export const InviteForm: React.FC<ApplicationProptype> = ({Application}) => {
   const [emails, changeEmails] = useState<EmailModel[]>([]);
-  const handleInviteEvent = (event: React.MouseEvent) => {
+  const sendEmails = (event: React.MouseEvent) => {
     event.preventDefault();
-    // request to server
+    Application.services.inviteService.send(emails);
+
   };
 
   return (
           <Form>
             <InviteUsers emails={emails} changeEmails={changeEmails}/>
-            <InviteButton onClick={handleInviteEvent}/>
+            <InviteButton onClick={sendEmails}/>
           </Form>
   );
 };

--- a/client/src/presentation/pages/invite-users/form/index.tsx
+++ b/client/src/presentation/pages/invite-users/form/index.tsx
@@ -3,7 +3,7 @@ import React, {useState} from "react";
 import {InviteUsers} from "presentation/pages/invite-users/form/invite-users";
 import {InviteButton} from "presentation/pages/invite-users/form/Invite-button";
 import {EmailModel} from "core/model/email-model";
-import {ApplicationProptype} from "prop-types/application-type";
+import {AppSocketInviteMatchProps} from "prop-types/match-extends-types";
 
 const Form = styled.form`
   display: flex;
@@ -12,18 +12,18 @@ const Form = styled.form`
   width: 40%;
 `;
 
-export const InviteForm: React.FC<ApplicationProptype> = ({Application}) => {
+export const InviteForm: React.FC<AppSocketInviteMatchProps> = ({match, history, Application}) => {
   const [emails, changeEmails] = useState<EmailModel[]>([]);
+  if (!match.params.snugId) return null;
   const sendEmails = (event: React.MouseEvent) => {
     event.preventDefault();
-    Application.services.inviteService.send(emails);
-
+    Application.services.inviteService.send(match.params.snugId, emails);
+    history.push("/");
   };
-
   return (
           <Form>
             <InviteUsers emails={emails} changeEmails={changeEmails}/>
-            <InviteButton onClick={sendEmails}/>
+            <InviteButton history={history} sendEmails={sendEmails}/>
           </Form>
   );
 };

--- a/client/src/presentation/pages/invite-users/index.tsx
+++ b/client/src/presentation/pages/invite-users/index.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import {PageLayout} from "presentation/components/atomic-reusable/page-layout";
 import {InviteUsersContainer} from "./container";
-import {AppSocketChannelMatchProps} from "prop-types/match-extends-types";
+import {AppSocketInviteMatchProps} from "prop-types/match-extends-types";
 
-export const InviteUsers: React.FC<AppSocketChannelMatchProps> = props => {
-  const { Application } = props;
+export const InviteUsers: React.FC<AppSocketInviteMatchProps> = props => {
   return (
           <PageLayout>
-            <InviteUsersContainer Application = { Application }/>
+            <InviteUsersContainer {...props} />
           </PageLayout>
   );
 };

--- a/client/src/presentation/pages/invite-users/index.tsx
+++ b/client/src/presentation/pages/invite-users/index.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import {PageLayout} from "presentation/components/atomic-reusable/page-layout";
 import {InviteUsersContainer} from "./container";
+import {AppSocketChannelMatchProps} from "prop-types/match-extends-types";
 
-export const InviteUsers: React.FC = () => {
+export const InviteUsers: React.FC<AppSocketChannelMatchProps> = props => {
+  const { Application } = props;
   return (
           <PageLayout>
-            <InviteUsersContainer/>
+            <InviteUsersContainer Application = { Application }/>
           </PageLayout>
   );
 };

--- a/client/src/prop-types/invite-match-type.ts
+++ b/client/src/prop-types/invite-match-type.ts
@@ -1,0 +1,8 @@
+import { RouteComponentProps } from "react-router";
+
+export interface InviteMatchType {
+  snugId: string;
+}
+
+export interface InviteRouteComponentType
+        extends RouteComponentProps<InviteMatchType> {}

--- a/client/src/prop-types/match-extends-types.ts
+++ b/client/src/prop-types/match-extends-types.ts
@@ -1,7 +1,13 @@
 import { Context } from "./../context.instance";
 import { ChannelRouteComponentType } from "./channel-match-type";
+import {InviteRouteComponentType} from "./invite-match-type";
 
 export interface AppSocketChannelMatchProps extends ChannelRouteComponentType {
+  Application: Context;
+  socket: any;
+}
+
+export interface AppSocketInviteMatchProps extends InviteRouteComponentType {
   Application: Context;
   socket: any;
 }


### PR DESCRIPTION
## Related Issue

>  #101 

## Description and Motivation

1. 초대할 Email 리스트를 API 서버에 전송하는 기능 추가
2. "초대하기" 버튼 이벤트에 대한 리스너로 InviteService.send() 메서드를 호출하여 이메일 리스트 전송

### API 요청 형식
- URL : /api/invite
- Method: POST
- Body
```json
{
  "emails": [
    "GiPyoo@naver.com",
    "sangwon21@naver.com"
    "kyungrae@naver.com"
    // ...
  ]
}
```

## Types of changes

- [ ] Docs change
- [ ] dependency upgrade
- [ ] refactoring
- [ ] Bug fix 
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Review

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.