### PR TITLE
[김기표] w5_리뷰요청_로그인과_토큰관리

### DIFF
--- a/review/core/entity/token.ts
+++ b/review/core/entity/token.ts
@@ -1,0 +1,3 @@
+export interface WebToken<T> {
+  token: T;
+}

--- a/review/core/entity/user.ts
+++ b/review/core/entity/user.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id?: number;
+  email?: string;
+  name?: string;
+  password?: string;
+}

--- a/review/core/model/json-web-token-model.ts
+++ b/review/core/model/json-web-token-model.ts
@@ -1,0 +1,7 @@
+import { WebToken } from "core/entity/token";
+export class JsonWebToken implements WebToken<string> {
+  readonly token: string;
+  constructor(token: string) {
+    this.token = token;
+  }
+}

--- a/review/core/service/auth-service.ts
+++ b/review/core/service/auth-service.ts
@@ -1,0 +1,32 @@
+import { User } from "core/entity/user";
+import { AuthRepositoryType } from "core/use-case/auth-repository-type";
+
+export class AuthService {
+  private repository: AuthRepositoryType;
+
+  constructor(repository: AuthRepositoryType) {
+    this.repository = repository;
+  }
+
+  async login(email: string, password: string): Promise<boolean> {
+    const user: User = { email, password };
+    const JsonWebToken = await this.repository.login(user);
+    console.log(JsonWebToken);
+    if (!JsonWebToken.token) return false;
+    this.repository.setToken(JsonWebToken.token);
+    return true;
+  }
+
+  getUserInfo(): User {
+    const user = this.repository.getUserInfo();
+    return user;
+  }
+
+  isLogined(): boolean {
+    return this.repository.isLogined();
+  }
+
+  logout(): boolean {
+    return this.repository.logout();
+  }
+}

--- a/review/data/browser-storage/browser-storage-helper.ts
+++ b/review/data/browser-storage/browser-storage-helper.ts
@@ -1,0 +1,39 @@
+export enum StorageType {
+  LOCAL = "local",
+  SESSION = "session"
+}
+
+export type BrowserStorageKey = string;
+
+export class BrowserStorageHelper {
+  private storageType: StorageType;
+  private storage: Storage;
+
+  constructor(storageType: StorageType) {
+    this.storageType = storageType;
+    this.storage = this.setStorage(this.storageType);
+  }
+
+  private setStorage(storageType: StorageType) {
+    switch (storageType) {
+      case StorageType.LOCAL:
+        return localStorage;
+      case StorageType.SESSION:
+        return sessionStorage;
+      default:
+        throw new Error("존재하지 않는 스토리지 입니다.");
+    }
+  }
+
+  get(key: BrowserStorageKey) {
+    return this.storage.getItem(key);
+  }
+
+  set(key: BrowserStorageKey, target: string) {
+    this.storage.setItem(key, target);
+  }
+
+  clear(key: BrowserStorageKey) {
+    this.storage.removeItem(key);
+  }
+}

--- a/review/data/browser-storage/browser-storage-mapper.ts
+++ b/review/data/browser-storage/browser-storage-mapper.ts
@@ -1,0 +1,6 @@
+export interface BrowserStorageMapper<E> {
+  fromJson(json: string): E;
+  toJson(target: E): string;
+}
+
+//참고 : https://medium.com/rainist-engineering/safe-localstorage-using-typescdript-eac147f59ae

--- a/review/data/browser-storage/browser-storage.ts
+++ b/review/data/browser-storage/browser-storage.ts
@@ -1,0 +1,44 @@
+import { BrowserStorageMapper } from "./browser-storage-mapper";
+import {
+  BrowserStorageKey,
+  BrowserStorageHelper,
+  StorageType
+} from "./browser-storage-helper";
+
+export class BrowserStorage<E> {
+  private key: BrowserStorageKey;
+  private mapper: BrowserStorageMapper<E>;
+  private helper: BrowserStorageHelper;
+
+  constructor(
+    key: BrowserStorageKey,
+    mapper: BrowserStorageMapper<E>,
+    storageType: StorageType
+  ) {
+    this.key = key;
+    this.mapper = mapper;
+    this.helper = new BrowserStorageHelper(storageType);
+  }
+
+  isNull(value: any) {
+    if (value == null) return true;
+    return false;
+  }
+
+  get(): E | null {
+    const value = this.helper.get(this.key);
+    if (this.isNull(value)) return null;
+    return this.mapper.fromJson(value!);
+  }
+
+  set(target: E) {
+    const targetValue = this.mapper.toJson(target);
+    this.helper.set(this.key, targetValue);
+  }
+
+  clear() {
+    this.helper.clear(this.key);
+  }
+}
+
+//참고 : https://medium.com/rainist-engineering/safe-localstorage-using-typescdript-eac147f59ae

--- a/review/data/browser-storage/custom-mapper/json-web-tocken-mapper.ts
+++ b/review/data/browser-storage/custom-mapper/json-web-tocken-mapper.ts
@@ -1,0 +1,13 @@
+import { BrowserStorageMapper } from "../browser-storage-mapper";
+import { JsonWebToken } from "core/model/json-web-token-model";
+export class JsonWebTokenMapper implements BrowserStorageMapper<JsonWebToken> {
+  fromJson(json: string) {
+    const value = JSON.parse(json);
+    return new JsonWebToken(value.token);
+  }
+  toJson(target: JsonWebToken) {
+    return JSON.stringify({
+      token: target.token
+    });
+  }
+}

--- a/review/data/http/api/auth-api.ts
+++ b/review/data/http/api/auth-api.ts
@@ -1,0 +1,34 @@
+import { User } from "core/entity/user";
+import { AxiosErrorHandler } from "data/http/api/axiosErrorHandler";
+import { StatusCodes } from "./status-codes";
+import { AxiosResponse, AxiosError, AxiosInstance } from "axios";
+import { AxiosWrapper } from "./axios-wrapper";
+import { ResponseEntity } from "./response/ResponseEntity";
+import { WebToken } from "core/entity/token";
+
+export class AuthApi {
+  private axios: AxiosInstance;
+
+  constructor(axios: AxiosWrapper) {
+    this.axios = axios.getAxios();
+  }
+
+  login(user: User): Promise<ResponseEntity<WebToken<string>> | boolean> {
+    return this.axios
+      .post("/api/auth/login", user)
+      .then(
+        ({ data, status }: AxiosResponse<ResponseEntity<WebToken<string>>>) => {
+          if (StatusCodes.isOk(status)) {
+            return data;
+          }
+          throw new Error("로그인에 실패 했습니다.");
+        }
+      )
+      .catch((error: AxiosError) => {
+        return AxiosErrorHandler.handleError(
+          error,
+          `로그인을 하는 과정에서 문제가 발생했습니다. : ${error.message}`
+        );
+      });
+  }
+}

--- a/review/data/http/api/response/ResponseEntity.ts
+++ b/review/data/http/api/response/ResponseEntity.ts
@@ -1,0 +1,4 @@
+export interface ResponseEntity<T> {
+  message: string,
+  payload: T
+}

--- a/review/data/repository/auth-repository.ts
+++ b/review/data/repository/auth-repository.ts
@@ -1,0 +1,69 @@
+import { JsonWebToken } from "core/model/json-web-token-model";
+import { AuthRepositoryType } from "core/use-case/auth-repository-type";
+import { AuthApi } from "data/http/api/auth-api";
+import { BrowserStorage } from "data/browser-storage/browser-storage";
+import jwt from "jsonwebtoken";
+import { User } from "core/entity/user";
+import { WebToken } from "core/entity/token";
+
+export class AuthRepository implements AuthRepositoryType {
+  private api: AuthApi;
+  private storage: BrowserStorage<JsonWebToken>;
+
+  constructor(api: AuthApi, storage: BrowserStorage<JsonWebToken>) {
+    this.api = api;
+    this.storage = storage;
+  }
+
+  getUserInfo(): User {
+    try {
+      const result = this.storage.get();
+      if (result == null) return {};
+      const payload: { [key: string]: any } = <object>jwt.decode(result.token);
+      const user: User = {
+        email: payload.email
+      };
+      return user;
+    } catch (error) {
+      return {};
+    }
+  }
+
+  setToken(token: string): void {
+    try {
+      this.storage.set(new JsonWebToken(token));
+    } catch (error) {
+      return;
+    }
+  }
+
+  async login(user: User): Promise<WebToken<string>> {
+    try {
+      const result = await this.api.login(user);
+      if (typeof result === "boolean")
+        throw new Error("로그인에 실패했습니다.");
+      return result.payload;
+    } catch (error) {
+      return { token: "" };
+    }
+  }
+
+  isLogined(): boolean {
+    try {
+      const result = this.storage.get();
+      if (result == null) return false;
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  logout(): boolean {
+    try {
+      this.storage.clear();
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+}

--- a/review/presentation/components/atomic-reusable/global-header.tsx
+++ b/review/presentation/components/atomic-reusable/global-header.tsx
@@ -7,27 +7,6 @@ import { IconBox } from "./icon-box";
 import { ApplicationProptype } from "prop-types/application-type";
 import { Link } from "react-router-dom";
 
-const Wrapper = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background-color: #4096cb;
-  padding: 10px;
-  height: 5vh;
-  box-sizing: border-box;
-`;
-
-const IconBoxWrapper = styled.section`
-  display: flex;
-  justify-content: flex-end;
-  width: 80%;
-`;
-
-const DropDown = styled.section`
-  position: relative;
-  display: inline-block;
-`;
-
 interface On {
   on: boolean;
 }
@@ -88,7 +67,9 @@ export const GlobalHeader: React.FC<ApplicationProptype> = ({
 
   return (
     <Wrapper>
-      <Link to="/"><Title> Snug </Title></Link>
+      <Link to="/">
+        <Title> Snug </Title>
+      </Link>
       {isLoggedIn ? (
         <IconBoxWrapper>
           <DropDown onClick={clickDropdown} onMouseLeave={mouseLeave}>
@@ -111,7 +92,7 @@ export const GlobalHeader: React.FC<ApplicationProptype> = ({
             name={"회원가입"}
             fontColor={"#ffffff"}
             fontWeight={"bold"}
-        ></CustomButton>
+          ></CustomButton>
         </Link>
       )}
     </Wrapper>

--- a/review/presentation/components/atomic-reusable/global-header.tsx
+++ b/review/presentation/components/atomic-reusable/global-header.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import Dubu from "assets/dubu.png";
+import Notification from "assets/notification.png";
+import { CustomButton } from "./custom-button";
+import { IconBox } from "./icon-box";
+import { ApplicationProptype } from "prop-types/application-type";
+import { Link } from "react-router-dom";
+
+const Wrapper = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #4096cb;
+  padding: 10px;
+  height: 5vh;
+  box-sizing: border-box;
+`;
+
+const IconBoxWrapper = styled.section`
+  display: flex;
+  justify-content: flex-end;
+  width: 80%;
+`;
+
+const DropDown = styled.section`
+  position: relative;
+  display: inline-block;
+`;
+
+interface On {
+  on: boolean;
+}
+
+const ContentWrapper = styled.section<On>`
+  display: ${({ on }) => {
+    if (!on) return "none";
+    return "block";
+  }};
+  position: absolute;
+  transform: translateX(-80%);
+  background-color: #f9f9f9;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+`;
+
+const Content = styled.article`
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  &:hover {
+    background-color: #f1f1f1;
+  }
+`;
+
+const Title = styled.section`
+  color: #ffffff;
+  font-size: 1.4rem;
+`;
+
+export const GlobalHeader: React.FC<ApplicationProptype> = ({
+  Application
+}) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [on, setOn] = useState(false);
+
+  useEffect(() => {
+    setIsLoggedIn(Application.services.authService.isLogined());
+  });
+
+  function clickDropdown() {
+    setOn(on == false);
+  }
+
+  function mouseLeave() {
+    if (on) setOn(false);
+  }
+
+  function logout() {
+    Application.services.authService.logout();
+    window.location.href = "/";
+  }
+
+  return (
+    <Wrapper>
+      <Link to="/"><Title> Snug </Title></Link>
+      {isLoggedIn ? (
+        <IconBoxWrapper>
+          <DropDown onClick={clickDropdown} onMouseLeave={mouseLeave}>
+            <IconBox imageSrc={Dubu} />
+            <ContentWrapper on={on}>
+              <Content>프로필</Content>
+              <Link to="register-snug">
+                <Content>Snug 만들기</Content>
+              </Link>
+              <Content onClick={logout}>로그아웃</Content>
+            </ContentWrapper>
+          </DropDown>
+          <IconBox imageSrc={Notification} />
+        </IconBoxWrapper>
+      ) : (
+        <Link to="/register-user">
+          <CustomButton
+            color={"#fda600"}
+            size={"big"}
+            name={"회원가입"}
+            fontColor={"#ffffff"}
+            fontWeight={"bold"}
+        ></CustomButton>
+        </Link>
+      )}
+    </Wrapper>
+  );
+};

--- a/review/presentation/pages/home/home-form.tsx
+++ b/review/presentation/pages/home/home-form.tsx
@@ -1,0 +1,122 @@
+import React, { useState, ChangeEvent } from "react";
+import styled from "styled-components";
+import { CustomLoginInput } from "presentation/components/atomic-reusable/custom-login-input";
+import { CustomButton } from "presentation/components/atomic-reusable/custom-button";
+import { User } from "core/entity/user";
+import { ApplicationProptype } from "prop-types/application-type";
+import { validateEmail } from "presentation/validation/validation";
+
+const Wrapper = styled.form`
+  background-color: #ffffff;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;
+
+const DescriptionWrapper = styled.section`
+  height: 30%;
+  display: flex;
+  align-items: center;
+`;
+
+const SnugDescription = styled.span`
+  color: #000000;
+  font-weight: bold;
+  font-size: 2rem;
+`;
+
+const InputWrapper = styled.section`
+  height: 40%;
+  width: 30%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Input = styled.section``;
+
+const WarningText = styled.span`
+  color: red;
+`;
+
+const ButtonWrapper = styled.section`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const HomeForm: React.FC<ApplicationProptype> = (props) => {
+  const { Application } = props;
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [validEmail, setValidEmail] = useState(true);
+
+  const onChangeEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(event.target.value);
+    setValidEmail(validateEmail(event.target.value));
+  };
+
+  const onChangePassword = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  };
+
+  const login = async () => {
+    const result = await Application.services.authService.login(
+      email,
+      password
+    );
+    console.log(result);
+    if (!result) {
+      setEmail("");
+      setPassword("");
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <Wrapper>
+      <DescriptionWrapper>
+        <SnugDescription>아늑한 공간을 지금 바로 이용해보세요!</SnugDescription>
+      </DescriptionWrapper>
+      <InputWrapper>
+        <Input>
+          <CustomLoginInput
+            value={email}
+            color={"bdbdbd"}
+            backgroundColor={"#ffffff"}
+            placeholder={"예) XXX@XXX.XXX"}
+            onChange={onChangeEmail}
+          ></CustomLoginInput>
+          {!validEmail && (
+            <WarningText>유효한 이메일 형식이 아닙니다.</WarningText>
+          )}
+        </Input>
+        <Input>
+          <CustomLoginInput
+            value={password}
+            color={"bdbdbd"}
+            backgroundColor={"#ffffff"}
+            placeholder={"Password"}
+            onChange={onChangePassword}
+            type={"password"}
+          ></CustomLoginInput>
+        </Input>
+        <ButtonWrapper>
+          <CustomButton
+            type={"button"}
+            color={"#fda600"}
+            size={"50%"}
+            name={"로그인"}
+            fontSize={"1.5rem"}
+            fontColor={"#ffffff"}
+            fontWeight={"bold"}
+            height={"auto"}
+            onClick={login}
+          ></CustomButton>
+        </ButtonWrapper>
+      </InputWrapper>
+    </Wrapper>
+  );
+};

--- a/review/presentation/pages/home/index.tsx
+++ b/review/presentation/pages/home/index.tsx
@@ -1,0 +1,19 @@
+import React, { useState, useEffect } from "react";
+import { PageLayout } from "presentation/components/atomic-reusable/page-layout";
+import { HomeForm } from "./home-form";
+import { HomeSnug } from "./home-snug";
+import { ApplicationProptype } from "prop-types/application-type";
+
+export const Home: React.FC<ApplicationProptype> = ({ Application }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    setIsLoggedIn(Application.services.authService.isLogined());
+  });
+
+  return (
+    <PageLayout Application={Application}>
+      {isLoggedIn ? <HomeSnug /> : <HomeForm Application={Application} />}
+    </PageLayout>
+  );
+};


### PR DESCRIPTION
## Related Issue

>  #105 #106 #107

## 코드 설명
- 이 코드는 기본적으로 로그인을 구현한 프론트 코드입니다. 로그인을 할 때 로그인의 응답으로 jwt 를 받아 로컬 스토리지에 저장하는 기능들이 있습니다. 
- 코드의 기반은 뱅크샐러드의 클린 아키텍쳐를 참고하여 구조를 잡았습니다.
- 브라우져 스토리지는 로컬 스토리지 혹은 세션 스토리지로 사용할 수 있게하기 위하여 추상화 했고 실제 디펜던시를 주입할 때 jwt 스토리지를 만듭니다. 이 스토리지에 토큰을 저장합니다.
- 토큰은 사라지지 않고 지속됩니다.
- 여기 코드에는 프론트에 로그아웃을 하는 부분이 없지만 레포나 기능들에는 있는데, 로그아웃을 할 시에 api요청을 보내는 것이 아닌 스토리지를 삭제하였습니다.
- 또 로그인의 유무를 확인하여 다른 페이지를 보는 기능도 구현되어있습니다.

## 질문
- 토큰 인증 방식으로 로그인을 구현하였고 이 토큰을 local storage에 저장하는 방법을 사용하고 이 코드에는 없지만 axios 헤더에 토큰을 넣는 방법을 사용하였습니다. 이 과정에서 중간에 토큰 탈취가 걱정이 되는데 이 부분은 https를 적용한다면 해결되는 문제이니 신경을 쓸 필요가 없나요? 아니면, 실무에서 토큰 인증 방식을 쓸 때는 어떤 방식을 사용하는지 궁급합니다.
- 현재 페이지를 이동할때 다양한 방식을 사용하게 되는데 api와 요청이후에 결과에 따라 페이지를 이동하는 기능을 구현할 때 라우트프롭스에서 제공되는 history가 제 생각과는 달리 동작하여 window.location.href를 사용하는 경우가 있습니다. 왜냐하면  history.push를 사용하여 패스 파라미터를 바꾸면 전체적인 리렌더링이 발생하지 않는 경우가 있었습니다. 때문에 이 매치를 컨택스트에 저장하고 사용했습니다. 반면 window.location.href를 사용하면 새로고침이 되는 문제가 발생했습니다. 눈에 보이는 새로고침 없이 리랜더링 수 있는 페이지 이동 방법이 있다면 알려주세요!(패스파라미터를 바꾸어 라우트가 변경되지 않는 경우)

