### PR TITLE
[김경래] w5_리뷰요청_snug 생성 기능

### DIFF
--- a/review/src/app.ts
+++ b/review/src/app.ts
@@ -1,0 +1,52 @@
+import "dotenv/config";
+import "reflect-metadata";
+import express, { Express } from "express";
+import morgan from "morgan";
+import cookieParser from "cookie-parser";
+import { Connection, createConnection } from "typeorm";
+import postRouter from "./routes/post/post-router";
+import channelRouter from "./routes/channel/channel-router";
+import snugRouter from "./routes/snug/snug-router";
+import userRouter from "./routes/user/user-router";
+import authRouter from "./routes/auth/auth-router";
+import inviteRouter from "./routes/invite/invite-router";
+import indexRouter from "./routes/index";
+import dotenv from "dotenv";
+
+export default class App {
+  private static app: Express;
+  private static connection: Connection;
+
+  static async start() {
+    dotenv.config({path: __dirname.concat("/../")});
+    return await createConnection()
+      .then(connection => {
+        this.connection = connection;
+        return this.initializeExpress();
+      })
+      .catch(error => console.error("TypeORM Connection Error: ", error));
+  }
+
+  private static initializeExpress() {
+    this.app = express();
+    this.app.set("port", process.env.PORT || 3000);
+    this.app.set("env", process.env.NODE_ENV);
+    this.app.use(express.static("public"));
+    this.app.use(morgan("dev"));
+    this.app.use(express.json());
+    this.app.use(express.urlencoded({ extended: false }));
+    this.app.use(cookieParser(process.env.COOKIE_SECRET));
+    this.app.use("/api/posts", postRouter);
+    this.app.use("/api/channels", channelRouter);
+    this.app.use("/api/snugs", snugRouter);
+    this.app.use("/api/auth", authRouter);
+    this.app.use("/api/users", userRouter);
+    this.app.use("/api/invite", inviteRouter);
+    this.app.use("/", indexRouter);
+    return this.app;
+  }
+
+  static getEntityManager() {
+    return this.connection.manager;
+  }
+}

--- a/review/src/controller/api/common/messages.ts
+++ b/review/src/controller/api/common/messages.ts
@@ -1,0 +1,34 @@
+export const FOUND_CHANNEL = "found channel";
+
+export const NOT_FOUND_CHANNEL =
+  "not found channel, you must right channel title";
+
+export const CREATE_CHANNEL = "create new channel";
+
+export const FOUND_CHANNELS = "found channel list";
+
+export const NOT_FOUND_CHANNELS = "not found channel list";
+
+export const FOUND_POST_PROFILE = "found post with profile";
+
+export const NOT_FOUND_PROFILE = "not found profile, you must right profile id";
+
+export const ALREADY_EXIST_CHANNEL = "given channel title already exists";
+
+export const NOT_ELEGIBLE_USER_FORM = "included not appropriate user register form";
+
+export const CANNOT_CREATE_USER = "cannot create user";
+
+export const CREATE_USER_SUCCESSFULLY = "created user successfully";
+
+export const FOUND_EMAIL_USER = "found user with this email";
+
+export const NO_USER_WITH_EMAIL = "no user with this email";
+
+export const SUCCESS_INVITE="successfully sent all your emails and alarm";
+
+export const FAIL_INVITE="All emails and alarms have failed";
+
+export const CREATED_SNUG = "snug was created";
+
+export const OK_SNUG = "found snug";

--- a/review/src/controller/api/snug-controller.ts
+++ b/review/src/controller/api/snug-controller.ts
@@ -1,0 +1,87 @@
+import {getManager} from "typeorm";
+import {User} from "../../domain/entity/User";
+import {Snug} from "../../domain/entity/Snug";
+import {Profile} from "../../domain/entity/Profile";
+import {Room} from "../../domain/entity/Room";
+import {ParticipateIn} from "../../domain/entity/ParticipateIn";
+import {NextFunction, Request, Response} from "express";
+import ResponseForm from "../../utils/response-form";
+import {OK, CREATED, INTERNAL_SERVER_ERROR} from "http-status-codes";
+import {offerTokenInfo, UserInfo} from "../../validator/identifier-validator";
+import { CREATED_SNUG, OK_SNUG } from "./common/messages"
+
+/**
+ * client에서 보내온 메시지를 기반으로 snug를 DB에 저장
+ * Snug, Profile, Room, ParticipateIn에 데이터 생성
+ * */
+export const create = async (request: Request, response: Response, next: NextFunction) => {
+    const { name, description, thumbnail } = request.body;
+    const userInfo: UserInfo = offerTokenInfo(request);
+
+    try {
+        await getManager().transaction(async transactionalEntityManager => {
+            /**
+             * 1. snug row 생성
+             * 2. 전달된 userID를 통해 profile row를 저장
+             * 3. 생성된 snug를 통해 room row 저장
+             * 4. 생성된 profile과 room을 통해 particiapte in 저장
+             */
+            const snug: Snug = new Snug();
+            snug.name = name;
+            snug.description = description;
+            snug.thumbnail = thumbnail;
+            const resultSnug = await transactionalEntityManager.save(snug);
+
+            // 미들웨어에 user 객체가 존재 or db 조회
+            const user: User = await transactionalEntityManager.findOne(User, userInfo.id);
+
+            const profile: Profile = new Profile();
+            profile.name = user.name;
+            profile.status = "";
+            profile.role = "admin";
+            profile.user = user;
+            const resultProfile = await transactionalEntityManager.save(profile);
+            
+            // room 생성
+            const room: Room = new Room();
+
+            room.title = "기본 채널";
+            room.isPrivate = false;
+            room.isChannel = true;
+            room.snug = resultSnug;
+            room.creator = profile;
+            const resultRoom = await transactionalEntityManager.save(room);
+            
+            // participate
+            const particiapteIn: ParticipateIn = new ParticipateIn();
+            particiapteIn.participant = resultProfile;
+            particiapteIn.room = resultRoom;
+            const particiapteInResult = await transactionalEntityManager.save(particiapteIn);
+            
+            const responseForm = ResponseForm.of<Snug>(CREATED_SNUG, resultSnug);
+            response.status(CREATED).json(responseForm);
+        });
+    } catch (error) {
+        return response.status(INTERNAL_SERVER_ERROR).json(ResponseForm.of(error.messagenp));
+    }
+};
+
+
+/**
+ * jwt에 저장된 token을 이용하여 사용자가 참여하고 있는 snug list 보내주는 함수
+ */
+export const findByUserId = async (request: Request, response: Response, next: NextFunction) => {
+    try {
+        const userInfo: UserInfo = offerTokenInfo(request);
+
+        const user: User = await User.findOne(userInfo.id);
+        const profiles: Profile[] = await getManager().find(Profile ,{ where: { user: user }, relations: ["snug"] });
+        const snugs: Snug[] = profiles.map((profile) => {
+            return profile.snug
+        });
+
+        response.status(OK).json(ResponseForm.of<Snug[]>(OK_SNUG, snugs));
+    } catch(error) {
+        return response.status(INTERNAL_SERVER_ERROR).json(ResponseForm.of(error.messagenp));
+    }
+} 

--- a/review/src/domain/entity/Base.ts
+++ b/review/src/domain/entity/Base.ts
@@ -1,0 +1,8 @@
+import {BaseEntity, CreateDateColumn, UpdateDateColumn} from "typeorm";
+
+export class Base extends BaseEntity {
+  @CreateDateColumn()
+  createdAt: Date;
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/review/src/domain/entity/ParticipateIn.ts
+++ b/review/src/domain/entity/ParticipateIn.ts
@@ -1,0 +1,15 @@
+import { BaseEntity, Entity, PrimaryGeneratedColumn, ManyToOne } from "typeorm";
+import { Profile } from "./Profile";
+import { Room } from "./Room";
+
+@Entity()
+export class ParticipateIn extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(type => Profile)
+  participant: Profile;
+
+  @ManyToOne(type => Room)
+  room: Room;
+}

--- a/review/src/domain/entity/Profile.ts
+++ b/review/src/domain/entity/Profile.ts
@@ -1,0 +1,36 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import {Snug} from "./Snug";
+import {User} from "./User";
+import {Base} from "./Base";
+
+export type UserRoleType = "admin" | "participant";
+
+@Entity()
+export class Profile extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  status: string;
+
+  @Column({ nullable: true })
+  thumbnail: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({
+    type: "enum",
+    enum: ["admin", "member"]
+  })
+  role: UserRoleType;
+
+  @ManyToOne(type => Snug)
+  snug: Snug;
+
+  @ManyToOne(type => User)
+  user: User;
+}

--- a/review/src/domain/entity/Room.ts
+++ b/review/src/domain/entity/Room.ts
@@ -1,0 +1,32 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import {Profile} from "./Profile";
+import {Snug} from "./Snug";
+import {Base} from "./Base";
+
+@Entity()
+export class Room extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column()
+  isPrivate: boolean;
+
+  @Column()
+  isChannel: boolean;
+
+  @ManyToOne(type => Profile)
+  creator: Profile;
+
+  @ManyToOne(type => Snug)
+  snug: Snug;
+
+  static findByTitle(title: string): Promise<Room> {
+    return Room.findOne({where: {title: title}});
+  }
+}

--- a/review/src/domain/entity/Snug.ts
+++ b/review/src/domain/entity/Snug.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { Base } from "./Base";
+import {Invite} from "./Invite";
+
+@Entity()
+export class Snug extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  thumbnail: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @OneToMany(type => Invite, invite => invite.snug)
+  invitations: Invite[];
+}

--- a/review/src/domain/entity/User.ts
+++ b/review/src/domain/entity/User.ts
@@ -1,0 +1,33 @@
+import {Column, Entity, In, PrimaryGeneratedColumn} from "typeorm";
+import {Base} from "./Base";
+import {Email} from "../vo/Email";
+import _ from "lodash";
+
+@Entity()
+export class User extends Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column(type=> Email)
+  email: Email;
+
+  @Column()
+  name: string;
+
+  @Column()
+  password: string;
+
+  constructor(email?: Email) {
+    super();
+    this.email = email;
+  }
+
+  static findByEmails(emails: string[]): Promise<User[]> {
+    const emailValues = emails.map(email => new Email(email));
+    return User.find({ email: In(emailValues) });
+  }
+
+  hasSameEmail(email: string): boolean {
+    return _.isEqual(this.email.asFormat(), email);
+  }
+}

--- a/review/src/routes/index.ts
+++ b/review/src/routes/index.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import * as IndexController from "../controller/index-controller";
+
+const router = Router();
+
+router.get("/", IndexController.index);
+export default router;

--- a/review/src/routes/snug/snug-router.ts
+++ b/review/src/routes/snug/snug-router.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import inviteRouter from "./invite/invite-router";
+import {isNumeric} from "../../validator/identifier-validator";
+import { create } from "../../controller/api/snug-controller";
+
+const router = Router({mergeParams: true});
+
+router.use("/:snugId/invite", inviteRouter);
+
+router.post("/", create);
+
+router.param("snugId", isNumeric);
+export default router;

--- a/review/src/server.ts
+++ b/review/src/server.ts
@@ -1,0 +1,12 @@
+import Application from "./app";
+import {Express} from "express";
+import {Server} from "http";
+import {initialize} from "./socket/socket-manager";
+
+Application.start()
+        .then((app: Express) => {
+          const server: Server = app.listen(app.get("port"), () => {
+            console.log("listen port", app.get("port"));
+            initialize(server);
+          });
+        });

--- a/review/src/tsconfig.json
+++ b/review/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/review/src/validator/identifier-validator.ts
+++ b/review/src/validator/identifier-validator.ts
@@ -1,0 +1,119 @@
+import { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+import { User } from "../domain/entity/User";
+
+enum Numbers {
+  MIN_CHARACTER_DIGIT = 0,
+  MAX_CHARACTER_DIGIT = 9,
+  MIN_INTEGER_ID = 0,
+  MAX_INTEGER_ID = Math.pow(2, 31)
+}
+
+/**
+ *
+ * 한 자리 문자의 0 ~ 9 숫자 범위 포함 여부 확인
+ *
+ * @param character 0 ~ 9 범위의 한 자리 문자열
+ * @return boolean 미포함 true, 포함 false
+ *
+ * */
+export const isOutOfRangeChar = (character: string): boolean => {
+  const digit = parseInt(character);
+  return !(
+    Numbers.MIN_CHARACTER_DIGIT <= digit && digit <= Numbers.MAX_CHARACTER_DIGIT
+  );
+};
+
+/**
+ *
+ * 입력받은 문자열이 숫자로만 이루어져 있는 지 확인
+ *
+ * @param target 문자열
+ * @return boolean 모든 문자가 숫자가 아닌 경우 true, 모든 문자가 숫자인 경우 false
+ *
+ * */
+export const hasNotEveryNumber = (target: string): boolean => {
+  const DELIMITER = "";
+  return target.split(DELIMITER).some(isOutOfRangeChar);
+};
+
+/**
+ *
+ * 빈 문자열, null, undefined 여부 확인
+ *
+ * @param target 문자열
+ * @return boolean 빈 문자열, null, undefined 중 하나인 경우 true, 아닌 경우 false
+ *
+ * */
+export const hasNotValue = (target: string) => {
+  return !target;
+};
+
+/**
+ *
+ * 입력받은 문자열의 정수값의 (1 ~ 2^31 - 1) 범위 포함 여부 확인
+ *
+ * @param target 문자열
+ * @return boolean 미포함 true, 포함 false
+ *
+ * */
+export const isOutOfRange = (target: string): boolean => {
+  const digits = parseInt(target);
+  return !(Numbers.MIN_INTEGER_ID < digits && digits < Numbers.MAX_INTEGER_ID);
+};
+
+/**
+ *
+ * request path variable 인 id 대한 유효성 검사
+ * 유효한 경우, next() 메소드가 err 인자 없이 호출되고
+ * 유효하지 않은 경우, next(err) 메소드가 err 인자를 가지고 호출
+ *
+ * @param request express Request
+ * @param response express Response
+ * @param next express Next
+ * @param id
+ *
+ * */
+export const isNumeric = (
+  request: Request,
+  response: Response,
+  next: NextFunction,
+  id: string
+) => {
+  if (hasNotValue(id) || hasNotEveryNumber(id) || isOutOfRange(id)) {
+    return next("Invalid id format. Must be an Number");
+  }
+
+  next();
+};
+
+export const offerTokenInfo = (request: Request): UserInfo => {
+  const token = request.headers["auth-token"];
+  const decoded = <UserInfo>jwt.verify(<string>token, process.env.SECRET_KEY);
+  return decoded;
+};
+
+export const isVerifyLogined = async (
+  request: Request,
+  response: Response,
+  next: NextFunction
+) => {
+  try {
+    const token = request.headers["auth-token"];
+    if (!token) throw new Error("토큰이 존재하지 않습니다.");
+    const decoded = <UserInfo>(
+      jwt.verify(<string>token, process.env.SECRET_KEY)
+    );
+    const result = await User.findOne({ where: { email: decoded.email } });
+    if (!result) throw new Error("없는 유저입니다.");
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export type UserInfo = {
+  id: number;
+  name: string;
+  email: string;
+};


### PR DESCRIPTION
# ERD

![erd](https://user-images.githubusercontent.com/26711771/70291652-21e61100-181f-11ea-85e5-b899cb410800.png)

# 구현기능 

1. 스너그 생성 후 profile, room, participatein 테이블에 객체를 생성합니다.
snug, profile, room, participatein에 insert를 atomic하게 실행하게 하기위해 transaction을 사용했습니다.

2. user 정보를 통해 사용자 참여 리스트 보여주기
token 정보를 이용하여 현재 참여하고 있는 snug list를 보내줍니다.


# 질문

1. request
현재 인증 방식으로 webtoken을 사용하고 있습니다. passport를 사용하면 로그인 후 session id 비교 후 request 객체에 user를 등록해주어 다음 미들웨어에서 user를 쉽게 사용할 수 있습니다. web token을 이용해서 request 객체에 user 정보를 넣은 후 다음 미들웨어에서 user 정보를 쉽게 사용할 수 있나요??

2. error handler 등록
error 발생시 next(error)를 이용하여 `next(new Error())`와 같이 해서 에러 핸들링을 하고 싶은데 마지막 에러 핸들 미들웨어에서 error에 status와 같은 정보를 설정하고 싶은데 좋은 방법이 있을까요?
`errorHandler(error: Error, req: Request, res:Response, next: NextFunc)` error 객체에 http status code 같은 부가적인 정보를 담고 싶습니다.