### PR TITLE
여러 Snug에서 동일한 주소로 이메일 발송하지 못하는 이슈 

### DIFF
--- a/server/src/controller/api/user-controller.ts
+++ b/server/src/controller/api/user-controller.ts
@@ -1,25 +1,14 @@
-import { User } from "../../domain/entity/User";
-import { Request, Response } from "express";
+import {User} from "../../domain/entity/User";
+import {Request, Response} from "express";
 import ResponseForm from "../../utils/response-form";
-import { CREATED, OK, NOT_FOUND } from "http-status-codes";
-import {
-  CREATE_USER_SUCCESSFULLY,
-  FOUND_EMAIL_USER,
-  NO_USER_WITH_EMAIL
-} from "./common/messages";
-import { generateHashedPassword } from "../../utils/password/generate-password";
+import {CREATED, NOT_FOUND, OK} from "http-status-codes";
+import {CREATE_USER_SUCCESSFULLY, FOUND_EMAIL_USER, NO_USER_WITH_EMAIL} from "./common/messages";
+import {generateHashedPassword} from "../../utils/password/generate-password";
 import {Email} from "../../domain/vo/Email";
+import {Invitee} from "../../model/invite/invitee";
 
-/**
- *
- * client에서 보내온 메시지를 기반으로 post를 DB에 저장
- *
- * @param request
- * @param response
- *
- * */
 export const create = async (request: Request, response: Response) => {
-  const { email, name, password } = request.body;
+  const {email, name, password} = request.body;
   const hashedPassword = await generateHashedPassword(password);
   const emailModel = Email.from(email);
   const user = await User.save({
@@ -27,19 +16,20 @@ export const create = async (request: Request, response: Response) => {
     name,
     password: hashedPassword
   } as User);
+
+  const invitee = new Invitee();
+  await invitee.subscribeInvitations(user);
   const responseForm = ResponseForm.of<User>(CREATE_USER_SUCCESSFULLY, user);
   return response.status(CREATED).json(responseForm);
 };
-
 export const findByEmail = async (request: Request, response: Response) => {
   const email = request.params.email;
   const emailModel = Email.from(email);
-
   try {
-    const user = await User.findOneOrFail({ email: emailModel });
+    const user = await User.findOneOrFail({email: emailModel});
     return response
-      .status(OK)
-      .json(ResponseForm.of<User>(FOUND_EMAIL_USER, user));
+            .status(OK)
+            .json(ResponseForm.of<User>(FOUND_EMAIL_USER, user));
   } catch (error) {
     return response.status(NOT_FOUND).json(ResponseForm.of(NO_USER_WITH_EMAIL));
   }

--- a/server/src/domain/entity/Invite.ts
+++ b/server/src/domain/entity/Invite.ts
@@ -62,8 +62,16 @@ export class Invite extends Base {
     return Invite.findOne({where: {ticket: ticket.asObject()}});
   }
 
+  public static findByEmail(email: Email): Promise<Invite[]> {
+    return Invite.find({where: {email: email}});
+  }
+
   public static deleteBy(invite: Invite): Promise<Invite> {
     invite.deletedAt = new Date();
     return Invite.save(invite);
+  }
+
+  public mergeUser(user: User): Invite {
+    return Invite.merge(this, {user: user});
   }
 }

--- a/server/src/domain/entity/Invite.ts
+++ b/server/src/domain/entity/Invite.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, IsNull, JoinColumn, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import {Column, Entity, Index, IsNull, JoinColumn, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
 import {EmailContents} from "../../template/email-contents";
 import UrlInfo from "../../utils/url-info";
 import {Email} from "../vo/Email";
@@ -8,6 +8,7 @@ import {User} from "./User";
 import {Snug} from "./Snug";
 
 @Entity()
+@Index("invite_email_snug_uniq_index", ["snug.id", "email.localPart", "email.domain"], {unique: true})
 export class Invite extends Base {
   @PrimaryGeneratedColumn()
   id: number;

--- a/server/src/domain/entity/User.ts
+++ b/server/src/domain/entity/User.ts
@@ -1,9 +1,10 @@
-import {Column, Entity, PrimaryGeneratedColumn} from "typeorm";
+import {Column, Entity, Index, PrimaryGeneratedColumn} from "typeorm";
 import {Base} from "./Base";
 import {Email} from "../vo/Email";
 import _ from "lodash";
 
 @Entity()
+@Index("email_uniq_index", ["email.localPart", "email.domain"], {unique: true})
 export class User extends Base {
   @PrimaryGeneratedColumn()
   id: number;

--- a/server/src/domain/vo/Email.ts
+++ b/server/src/domain/vo/Email.ts
@@ -1,10 +1,9 @@
-import {Column, Index} from "typeorm";
+import {Column} from "typeorm";
 import {checkInvalidEmail} from "../../validator/email-validator";
 import InvalidEmailException from "../../utils/exception/InvalidEmailException";
 import {Transporter} from "nodemailer";
 import TransferEmailException from "../../utils/exception/TransferEmailException";
 
-@Index("email_uniq_index", ["localPart", "domain"], { unique: true })
 export class Email {
   @Column({length: 64})
   private readonly localPart: string;

--- a/server/src/migration/1576161811408-CHANGE-EMAIL-INDEX.ts
+++ b/server/src/migration/1576161811408-CHANGE-EMAIL-INDEX.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CHANGEEMAILINDEX1576161811408 implements MigrationInterface {
+    name = "CHANGEEMAILINDEX1576161811408";
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("DROP INDEX `email_uniq_index` ON `invite`", undefined);
+        await queryRunner.query("DROP INDEX `IDX_d3c3a6d023f98b06847bf7879a` ON `invite`", undefined);
+        await queryRunner.query("CREATE UNIQUE INDEX `invite_email_snug_uniq_index` ON `invite` (`snugId`, `emailLocalpart`, `emailDomain`)", undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query("DROP INDEX `invite_email_snug_uniq_index` ON `invite`", undefined);
+        await queryRunner.query("CREATE UNIQUE INDEX `IDX_d3c3a6d023f98b06847bf7879a` ON `invite` (`ticketId`)", undefined);
+        await queryRunner.query("CREATE UNIQUE INDEX `email_uniq_index` ON `invite` (`emailLocalpart`, `emailDomain`)", undefined);
+    }
+
+}

--- a/server/src/model/invite/invitee.ts
+++ b/server/src/model/invite/invitee.ts
@@ -6,6 +6,8 @@ import {Profile} from "../../domain/entity/Profile";
 import {Participant} from "../participant/participant";
 import {IsolationLevel, Propagation, Transactional} from "typeorm-transactional-cls-hooked";
 import {SnugInfo} from "../../model/snug/snug-info";
+import {User} from "../../domain/entity/User";
+import _ from "lodash";
 
 export class Invitee {
   async findInvitations(userId: string): Promise<InviteInfo[]> {
@@ -30,5 +32,12 @@ export class Invitee {
   async findInvitationByTicket(ticket: Ticket): Promise<SnugInfo> {
     const invite = await Invite.findByTicket(ticket);
     return SnugInfo.fromSnug(invite.snug);
+  }
+
+  @Transactional({propagation: Propagation.REQUIRED, isolationLevel: IsolationLevel.REPEATABLE_READ})
+  async subscribeInvitations(user: User): Promise<Invite[]> {
+    const invitations = await Invite.findByEmail(user.email);
+    const invitationsAboutSubscriber = _.map(invitations, invite => invite.mergeUser(user));
+    return Invite.save(invitationsAboutSubscriber);
   }
 }

--- a/server/src/utils/url-info.ts
+++ b/server/src/utils/url-info.ts
@@ -18,7 +18,7 @@ export default class UrlInfo {
   }
 
   static aboutServerDomain(): string {
-    return `${process.env.HOST}/${process.env.PORT}`;
+    return `${process.env.HOST}:${process.env.PORT}`;
   }
 
   static aboutHome(): string {


### PR DESCRIPTION

## Description and Motivation
#### Email 대한 Unique Index 설정으로 인해 중복된 초대 이메일 주소가 삽입되지 않는 이슈
-  Email 사용하는 Entity 측에서 Unique Index 설정하여, 여러 Snug 에서 동일한 email 주소로 초대 이메일 보낼 수 있다

## Types of changes

- [ ] Docs change
- [ ] dependency upgrade
- [ ] refactoring
- [X] Bug fix 
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Review

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.