### PR TITLE
[김경래] w6_리뷰요청_파일 업로드 프리뷰 및 로거 등록

### DIFF
--- a/review/client/chat-input-box/index.tsx
+++ b/review/client/chat-input-box/index.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect, useContext } from "react";
+import styled from "styled-components";
+import ClipWhite from "assets/clip-white.png";
+import AtWhite from "assets/at-white.png";
+import FaceWhite from "assets/face-white.png";
+import { IconBox } from "presentation/components/atomic-reusable/icon-box";
+import { useMessagesDispatch, useMessages } from "contexts/messages-context";
+import dubu from "assets/dubu.png";
+import { AppChannelMatchProps } from "prop-types/match-extends-types";
+import { ResponseEntity } from "data/http/api/response/ResponseEntity";
+import { Post } from "core/entity/post";
+import { usePathParameter } from "contexts/path-parameter-context";
+import { globalSocket } from "contexts/socket-context";
+
+interface PropType extends AppChannelMatchProps {
+  openModal: () => void;
+}
+
+export const ChatInputBox: React.FC<PropType> = props => {
+  const { Application, openModal } = props;
+
+  const KEY_PRESS_EVENT_KEY = "Enter";
+  const [message, setMessage] = useState("");
+  const [id, setId] = useState(0);
+  const dispatch = useMessagesDispatch();
+  const pathPrameter = usePathParameter();
+  const { snugSocket } = useContext(globalSocket);
+
+  const inputChangeEventHandler = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setMessage(event.target.value);
+  };
+
+  useEffect(() => {
+    snugSocket.off("newPost");
+    snugSocket.on("newPost", (resultData: ResponseEntity<Post>) => {
+      const { payload } = resultData;
+      if (payload.room != pathPrameter.channelId) return;
+      dispatch({
+        type: "CREATE",
+        id: payload.id!,
+        profile: {
+          name: payload.profile!.name! || "두부",
+          thumbnail: dubu
+        },
+        createdAt: payload.createdAt!,
+        updatedAt: payload.updatedAt!,
+        contents: payload.contents!
+      });
+    });
+  }, [pathPrameter]);
+
+  //이 부분은 mock 데이터로 되어 있으니 차후 수정이 필요함
+  const inputKeyPressEventHandler = async (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    event.stopPropagation();
+    if (event.key !== KEY_PRESS_EVENT_KEY) return;
+    if (!message.trim()) return;
+    if (!dispatch) return;
+
+    const result = await Application.services.postService.createMessage(
+      1,
+      message,
+      pathPrameter.channelId!
+    );
+    if (!result) return;
+    setId(id + 1);
+    setMessage("");
+  };
+
+  return (
+    <InputWrapper>
+      <MarginBox></MarginBox>
+      <CustomInput>
+        <IconBox imageSrc={ClipWhite} onClick={openModal}></IconBox>
+        <StyledInput
+          value={message}
+          onChange={inputChangeEventHandler}
+          onKeyPress={inputKeyPressEventHandler}
+        ></StyledInput>
+        <IconBox imageSrc={AtWhite}></IconBox>
+        <IconBox imageSrc={FaceWhite}></IconBox>
+      </CustomInput>
+      <MarginBox></MarginBox>
+    </InputWrapper>
+  );
+};

--- a/review/client/content.tsx
+++ b/review/client/content.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { ChatInputBox } from "./chat-input-box";
+import { FileUploadModal } from "./file-upload-modal";
+
+const MessageSectionContentWrapper = styled.section`
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.snug};
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+`;
+
+export const MessageSectionContent: React.FC<AppChannelMatchProps> = props => {
+  // file upload 모달
+  // modal state 관리하는 함수 전달
+  // file input changed 발생시 modal 활성화
+  const [onModal, setModal] = useState(false);
+
+  const openModal = () => {
+    setModal(true);
+  };
+
+  const closeModal = () => {
+    setModal(false);
+  };
+
+  // 파일 내용 state
+  return (
+    <MessageContextProvider>
+      {onModal && <FileUploadModal closeModal={closeModal} />}
+      <MessageSectionContentWrapper>
+        <ChatContent {...props} />
+        <ChatInputBox {...props} openModal={openModal} />
+      </MessageSectionContentWrapper>
+    </MessageContextProvider>
+  );
+};

--- a/review/client/file-preview/image-preview.tsx
+++ b/review/client/file-preview/image-preview.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+
+interface PropTypes {
+  file: File;
+}
+
+const ImgPreview = styled.img`
+  max-width: 100%;
+  max-height: 250px;
+`;
+
+export const ImagePreview: React.FC<PropTypes> = props => {
+  const { file } = props;
+  const [previewUrl, setPreviewUrl] = useState("");
+
+  const reader = new FileReader();
+  reader.readAsDataURL(file);
+  reader.onloadend = () => {
+    setPreviewUrl(reader.result as string);
+  };
+
+  return <ImgPreview src={previewUrl} />;
+};

--- a/review/client/file-preview/index.tsx
+++ b/review/client/file-preview/index.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+import { NormalPreview } from "./normal-preview";
+import { ImagePreview } from "./image-preview";
+import styled from "styled-components";
+
+interface PropTypes {
+  file: File;
+}
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.snugMainFont};
+  height: auto;
+  border: 1px solid ${({ theme }) => theme.snugBorderColor};
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+`;
+
+function isImage(fileName: string) {
+  if (/\.(gif|jpg|jpeg|tiff|png)$/i.test(fileName)) return true;
+  return false;
+}
+
+export const FilePreview: React.FC<PropTypes> = props => {
+  const { file } = props;
+
+  return (
+    <Container>
+      {isImage(file.name) ? (
+        <ImagePreview file={file} />
+      ) : (
+        <NormalPreview file={file} />
+      )}
+    </Container>
+  );
+};

--- a/review/client/file-preview/normal-preview.tsx
+++ b/review/client/file-preview/normal-preview.tsx
@@ -1,0 +1,25 @@
+import React, { Fragment } from "react";
+import styled from "styled-components";
+
+interface PropTypes {
+  file: File;
+}
+
+const CustomPreview = styled.div`
+  margin: 1rem;
+  padding: 1rem;
+  color: ${({ theme }) => theme.snugSubFont};
+  background: ${({ theme }) => theme.snug};
+  border-radius: 1rem;
+`;
+
+export const NormalPreview: React.FC<PropTypes> = props => {
+  const { file } = props;
+
+  return (
+    <CustomPreview>
+      <div>이름: {file.name}</div>
+      <div>크기: {file.size} Bytes</div>
+    </CustomPreview>
+  );
+};

--- a/review/client/file-upload-modal/file-drop-area.tsx
+++ b/review/client/file-upload-modal/file-drop-area.tsx
@@ -1,0 +1,48 @@
+import React, { CSSProperties, useState } from "react";
+import styled from "styled-components";
+
+const isHighLight: CSSProperties = {
+  background: "#ccc"
+};
+
+interface PropTypes {
+  setFile: React.Dispatch<React.SetStateAction<File>>;
+}
+
+export const FileDropArea: React.FC<PropTypes> = props => {
+  const [isDragging, setDragging] = useState(false);
+  const { setFile } = props;
+
+  const onDragOver: (event: React.DragEvent<HTMLDivElement>) => void = (
+    event: React.DragEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault();
+    setDragging(true);
+  };
+
+  const onDrop: (event: React.DragEvent<HTMLDivElement>) => void = (
+    event: React.DragEvent<HTMLDivElement>
+  ) => {
+    event.preventDefault();
+
+    setDragging(false);
+    props.setFile(event.dataTransfer.files[0]);
+  };
+
+  const onDragLeave: (event: React.DragEvent<HTMLDivElement>) => void = (
+    event: React.DragEvent<HTMLDivElement>
+  ) => {
+    setDragging(false);
+  };
+
+  return (
+    <Wrapper
+      style={isDragging ? isHighLight : undefined}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragLeave={onDragLeave}
+    >
+      <InfoMessage>Drop your file here</InfoMessage>
+    </Wrapper>
+  );
+};

--- a/review/client/file-upload-modal/index.tsx
+++ b/review/client/file-upload-modal/index.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { FileDropArea } from "./file-drop-area";
+import { FilePreview } from "../file-preview";
+
+const HiddenInput = styled.input.attrs({
+  type: "file"
+})`
+  display: none;
+`;
+
+interface PropTypes {
+  closeModal: () => void;
+}
+
+export const FileUploadModal: React.FC<PropTypes> = props => {
+  const [file, setFile] = useState(new File([], ""));
+  const onChange: (event: React.ChangeEvent<HTMLInputElement>) => void = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    event.preventDefault();
+    setFile(event.target.files![0]);
+  };
+
+  return (
+    <Modal>
+      <ModalContent>
+        <ModalHeader>
+          <CloseButton onClick={props.closeModal}>&times;</CloseButton>
+          파일 업로드
+        </ModalHeader>
+
+        <ModalBody>
+          <CustomInput>
+            <StyledInput />
+          </CustomInput>
+
+          <label htmlFor="fileInput">
+            <FileDropArea setFile={setFile} />
+          </label>
+          <HiddenInput id="fileInput" onChange={onChange} />
+          {file.size > 0 ? <FilePreview file={file} /> : undefined}
+        </ModalBody>
+
+        <ModalFooter>
+          <CustomButton
+            color={"#148567"}
+            fontColor={"#ffffff"}
+            name={"업로드"}
+            size={"big"}
+            fontWeight={"bold"}
+            fontSize={"1rem"}
+            height={"2.5rem"}
+          />
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/review/server/logger.ts
+++ b/review/server/logger.ts
@@ -1,0 +1,19 @@
+import winston from "winston";
+import { createLogger, format, transports } from "winston";
+
+const options: winston.LoggerOptions = {
+  level: "info",
+  format: format.json(),
+  transports: [
+    new transports.File({ filename: "combined.log" }),
+    new transports.File({ filename: "error.log", level: "error" })
+  ]
+};
+
+const logger = createLogger(options);
+
+if (process.env.NODE_ENV !== "production") {
+  logger.add(new transports.Console({ format: format.simple() }));
+}
+
+export default logger;


### PR DESCRIPTION
## Description and Motivation

![upload](https://user-images.githubusercontent.com/26711771/70798281-db2d8380-1de9-11ea-9284-c9611aee1fb5.png)

1. 파일 드래그 앤 드롭 및 파일 다이얼로그로를 이용하여 파일 업로드 전 미리보기를 할 수 있는 기능을 구현했습니다.

2. 배포했을 때, 에러 메세지를 기록하기 위해 winston을 이용하여 에러를 파일로 기록하는 logger를 구현했습니다.

## 질문
1. 클라우드에 서비스를 배포했을 때, 에러를 관리하기 쉽지 않은 것 같습니다. 실제 배포를 진행하니 코드 안에 존재하는 매직넘버(클라이언트, 서버 url 주소 등) 때문에 서비스가 깨지고 IDE의 부재로 디버깅이 어려웠습니다. 뒤늦게 자바스크립트에 로거 기능을 하는 winston 라이브러리를 적용하려고 합니다. 윈스턴(로거)을 적용해서 에러에 대응하고 싶은데 보통 모든 컨트롤러에서 로거를 참조하여 에러를 대응하나요?