### PR TITLE
프라이빗 채널 추가시, 사이드바에서 개인 채널로 분류되지 않는 이슈

### DIFF
--- a/client/src/core/use-case/channel-repository-type.ts
+++ b/client/src/core/use-case/channel-repository-type.ts
@@ -1,7 +1,7 @@
 import {Channel} from "core/entity/channel";
 import {Snug} from "core/entity/snug";
-import {ParticipateInfo} from "../entity/participate-info";
-import {ChannelModel} from "../model/channel-model";
+import {ParticipateInfo} from "core/entity/participate-info";
+import {ChannelModel} from "core/model/channel-model";
 
 export interface ChannelRepositoryType {
   create(channelModel: ChannelModel): Promise<Channel>;
@@ -10,7 +10,7 @@ export interface ChannelRepositoryType {
 
   join(channelInfo: Channel): Promise<ParticipateInfo>;
   
-  getParticipatingChannels(snug: Snug): Promise<Channel[] | boolean>;
+  getParticipatingChannels(snug: Snug): Promise<Channel[]>;
 
   getChannels(snug: Snug): Promise<Channel[] | boolean>;
 

--- a/client/src/data/http/api/channel-api.ts
+++ b/client/src/data/http/api/channel-api.ts
@@ -5,8 +5,9 @@ import {ResponseEntity} from "./response/ResponseEntity";
 import {StatusCodes} from "./status-codes";
 import {AxiosWrapper} from "./axios-wrapper";
 import {Snug} from "core/entity/snug";
-import {ParticipateInfo} from "../../../core/entity/participate-info";
-import {ChannelModel} from "../../../core/model/channel-model";
+import {ParticipateInfo} from "core/entity/participate-info";
+import {ChannelModel} from "core/model/channel-model";
+import {ChannelResponseType, ChannelsResponseType} from "./response/type/channel";
 
 export class ChannelApi {
   private axios: AxiosWrapper;
@@ -15,7 +16,7 @@ export class ChannelApi {
     this.axios = axios;
   }
 
-  create(channel: ChannelModel): Promise<{channel: Channel}> {
+  create(channel: ChannelModel): Promise<ChannelResponseType> {
     return this.axios
             .getAxios()
             .post(`/api/channels`, {
@@ -24,7 +25,7 @@ export class ChannelApi {
               description: channel.description!,
               privacy: channel.privacy!
             })
-            .then((response: AxiosResponse<ResponseEntity<{channel: Channel}>>) => {
+            .then((response: AxiosResponse<ResponseEntity<ChannelResponseType>>) => {
               if (StatusCodes.isCreated(response.status)) {
                 return response.data.payload;
               }
@@ -33,11 +34,11 @@ export class ChannelApi {
             });
   }
 
-  findByTitleAndSnugId(title: string, snugId: string): Promise<ResponseEntity<{channel: Channel}>> {
+  findByTitleAndSnugId(title: string, snugId: string): Promise<ResponseEntity<ChannelResponseType>> {
     return this.axios
             .getAxios()
             .get(`/api/snugs/${snugId}/channels/${title}`)
-            .then((response: AxiosResponse<ResponseEntity<{channel: Channel}>>) => {
+            .then((response: AxiosResponse<ResponseEntity<ChannelResponseType>>) => {
               if (StatusCodes.isOk(response.status)) {
                 return response.data;
               }
@@ -46,19 +47,16 @@ export class ChannelApi {
             });
   }
 
-  getParticipatingList(snug: Snug): Promise<ResponseEntity<object> | boolean> {
+  getParticipatingList(snug: Snug): Promise<ChannelsResponseType> {
     return this.axios
             .getAxios()
             .get(`/api/snugs/${snug.id!}/participates/channels`)
-            .then((response: AxiosResponse<ResponseEntity<object>>) => {
-              if (StatusCodes.isOk(response.status)) return response.data;
-              return false;
-            })
-            .catch((error: AxiosError) => {
-              return AxiosErrorHandler.handleError(
-                      error,
-                      `채널 목록을 불러오는 과정에서 예기치 못한 에러가 발생했습니다.`
-              );
+            .then((response: AxiosResponse<ResponseEntity<ChannelsResponseType>>) => {
+              if (StatusCodes.isOk(response.status)) {
+                return response.data.payload;
+              }
+
+              throw new Error(`채널 목록을 불러오는 과정에서 예기치 못한 에러가 발생했습니다.`);
             });
   }
 
@@ -78,11 +76,11 @@ export class ChannelApi {
             });
   }
 
-  getById(channelId: number): Promise<{channel: Channel}> {
+  getById(channelId: number): Promise<ChannelResponseType> {
     return this.axios
             .getAxios()
             .get(`/api/channels/${channelId}`)
-            .then((response: AxiosResponse<ResponseEntity<{channel: Channel}>>) => {
+            .then((response: AxiosResponse<ResponseEntity<ChannelResponseType>>) => {
               if (StatusCodes.isOk(response.status)) {
                 return response.data.payload;
               }

--- a/client/src/data/http/api/response/type/channel.ts
+++ b/client/src/data/http/api/response/type/channel.ts
@@ -1,0 +1,9 @@
+import {Channel} from "core/entity/channel";
+
+export interface ChannelResponseType {
+  channel: Channel
+}
+
+export interface ChannelsResponseType {
+  channels: Channel[]
+}

--- a/client/src/data/repository/channel-repository.ts
+++ b/client/src/data/repository/channel-repository.ts
@@ -1,11 +1,11 @@
-import {ResponseEntity} from "./../http/api/response/ResponseEntity";
-import {ChannelApi} from "../http/api/channel-api";
-import {Channel} from "../../core/entity/channel";
-import {ChannelRepositoryType} from "../../core/use-case/channel-repository-type";
+import {ResponseEntity} from "data/http/api/response/ResponseEntity";
+import {ChannelApi} from "data/http/api/channel-api";
+import {Channel} from "core/entity/channel";
+import {ChannelRepositoryType} from "core/use-case/channel-repository-type";
 import {Snug} from "core/entity/snug";
-import {hasNotCookie} from "../../util/cookie";
-import {ParticipateInfo} from "../../core/entity/participate-info";
-import {ChannelModel} from "../../core/model/channel-model";
+import {hasNotCookie} from "util/cookie";
+import {ParticipateInfo} from "core/entity/participate-info";
+import {ChannelModel} from "core/model/channel-model";
 
 export class ChannelRepository implements ChannelRepositoryType {
   private api: ChannelApi;
@@ -39,15 +39,9 @@ export class ChannelRepository implements ChannelRepositoryType {
     }
   }
 
-  async getParticipatingChannels(snug: Snug): Promise<Channel[] | boolean> {
-    try {
-      const responseEntity = await this.api.getParticipatingList(snug);
-      if (responseEntity)
-        return (responseEntity as ResponseEntity<{ channels: Channel[] }>).payload.channels;
-      return false;
-    } catch (error) {
-      return false;
-    }
+  async getParticipatingChannels(snug: Snug): Promise<Channel[]> {
+    const {channels} = await this.api.getParticipatingList(snug);
+    return channels;
   }
 
   join(channelInfo: Channel): Promise<ParticipateInfo> {

--- a/client/src/presentation/components/snug/channel-list/index.tsx
+++ b/client/src/presentation/components/snug/channel-list/index.tsx
@@ -39,8 +39,8 @@ interface PropTypes {
   Application: Context;
 }
 
-const pickPrivacy = (channels: Channels) => channels.filter(channel => channel.isPrivate);
-const pickPublicity = (channels: Channels) => channels.filter(channel => !channel.isPrivate);
+const pickPrivacy = (channels: Channels) => channels.filter(channel => channel.privacy);
+const pickPublicity = (channels: Channels) => channels.filter(channel => !channel.privacy);
 export const ChannelList: React.FC<PropTypes> = ({
                                                    match,
                                                    history,
@@ -58,12 +58,16 @@ export const ChannelList: React.FC<PropTypes> = ({
   useEffect(() => {
     (async function () {
       const snugId = Number(match.params.snugId);
-      const channel = await Application.services.channelService.getParticipatingChannelList(snugId);
-      if (typeof channel === "boolean" || !dispatch) return;
-      dispatch({
-        type: "MULTI",
-        channels: channel
-      });
+      try {
+        const channels = await Application.services.channelService.getParticipatingChannelList(snugId);
+        dispatch && dispatch({
+          type: "MULTI",
+          channels: channels
+        });
+      } catch (error) {
+        const homeUrl = "/";
+        history.push(homeUrl);
+      }
     })();
   }, []);
 


### PR DESCRIPTION
## Description and Motivation

### API 응답 데이터의 isPrivate 필드와 Client Channel 엔터티의 privacy 필드가 일치하지 않아 생기는 이슈

> isPrivate 필드를 Channel 엔터티의 privacy 필드로 변경하는 convertToChannel() 메서드 추가하여 해결


## Types of changes

- [ ] Docs change
- [ ] dependency upgrade
- [ ] refactoring
- [X] Bug fix 
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Review

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.