### PR TITLE
첫 번째 댓글의 카운트가 노출되지 않는 이슈

### DIFF
--- a/client/src/presentation/components/snug/post-card/post-card-contents.tsx
+++ b/client/src/presentation/components/snug/post-card/post-card-contents.tsx
@@ -100,7 +100,7 @@ export const PostCardContents: React.FC<PropTypes> = ({
         <></>
       )}
       {parseInt(replyCount) > 0 && (
-        <Thread>
+        <Thread onClick={toggleThread}>
           <ReplyNumber>{replyCount} 댓글</ReplyNumber>
         </Thread>
       )}

--- a/client/src/presentation/components/snug/thread-input-box/index.tsx
+++ b/client/src/presentation/components/snug/thread-input-box/index.tsx
@@ -78,7 +78,8 @@ export const ThreadInputBox: React.FC<PropTypes> = ({ addReply, thread }) => {
         post => Number(post.id) === payload.parent.id
       );
       const targetPost = posts[targetPostIndex];
-      targetPost.replyCount = (parseInt(targetPost.replyCount!) + 1).toString();
+      const replyCount = Number(targetPost.replyCount) || 0;
+      targetPost.replyCount = (replyCount + 1).toString();
       posts[targetPostIndex] = { ...targetPost };
       dispatch({
         type: "UPDATE_REPLYCOUNT",

--- a/server/src/controller/api/common/request/identifier/snug-identifier.ts
+++ b/server/src/controller/api/common/request/identifier/snug-identifier.ts
@@ -1,0 +1,3 @@
+export const SNUG = "snug";
+
+export const INVITED_SNUG = "invitedSnug";

--- a/server/src/controller/api/invite-controller.ts
+++ b/server/src/controller/api/invite-controller.ts
@@ -1,14 +1,8 @@
-import { NextFunction, Request, Response } from "express";
-import {
-  ACCEPTED,
-  CONFLICT,
-  FORBIDDEN,
-  OK,
-  UNPROCESSABLE_ENTITY
-} from "http-status-codes";
-import { Inviter } from "../../model/invite/inviter";
-import { EmailNotifier } from "../../model/notifier/email-notifier";
-import { InviteNotifier } from "../../model/notifier/invite-notifier";
+import {NextFunction, Request, Response} from "express";
+import {ACCEPTED, CONFLICT, FORBIDDEN, OK, UNPROCESSABLE_ENTITY} from "http-status-codes";
+import {Inviter} from "../../model/invite/inviter";
+import {EmailNotifier} from "../../model/notifier/email-notifier";
+import {InviteNotifier} from "../../model/notifier/invite-notifier";
 import {
   ALREADY_JOINED_SNUG,
   FOUND_INVITATIONS,
@@ -20,98 +14,103 @@ import {
 } from "./common/messages";
 import ResponseForm from "../../utils/response-form";
 import UrlInfo from "../../utils/url-info";
-import { Invitee } from "../../model/invite/invitee";
-import { Ticket } from "../../domain/vo/Ticket";
+import {Invitee} from "../../model/invite/invitee";
+import {Ticket} from "../../domain/vo/Ticket";
+import {INVITED_SNUG, SNUG} from "./common/request/identifier/snug-identifier";
+import _ from "lodash";
 
 export const invite = async (
-  request: Request,
-  response: Response
+        request: Request,
+        response: Response
 ): Promise<void> => {
-  const { snugId } = request.params;
-  const { emails } = request.body;
+  const {snugId} = request.params;
+  const {emails} = request.body;
   const inviter = new Inviter(new EmailNotifier(), new InviteNotifier());
   try {
     const invitations = await inviter.invite(snugId, emails);
     response.status(OK).json(
-      ResponseForm.of<object>(SUCCESS_INVITE, { invitations })
+            ResponseForm.of<object>(SUCCESS_INVITE, {invitations})
     );
+
   } catch (error) {
-    response.status(UNPROCESSABLE_ENTITY).json(
-      ResponseForm.of<object>(NOT_FOUND, {
-        link: UrlInfo.aboutHome(),
-        invitations: []
-      })
-    );
+    response.status(UNPROCESSABLE_ENTITY)
+            .json(ResponseForm.of<object>(NOT_FOUND, {
+              link: UrlInfo.aboutHome(),
+              invitations: []
+            }));
   }
 };
 
 export const findInvitations = async (
-  request: Request,
-  response: Response
+        request: Request,
+        response: Response
 ): Promise<void> => {
-  const { userId } = request.params;
+  const {userId} = request.params;
   const invitee = new Invitee();
   const invitations = await invitee.findInvitations(Number(userId));
-  response.status(OK).json(
-    ResponseForm.of<object>(FOUND_INVITATIONS, { invitations })
-  );
+  response.status(OK)
+          .json(ResponseForm.of<object>(FOUND_INVITATIONS, {invitations}));
 };
 
 export const verify = async (
-  request: Request,
-  response: Response,
-  next: NextFunction
+        request: Request,
+        response: Response,
+        next: NextFunction
 ): Promise<void> => {
-  const { ticket } = request.params;
-  const { agree } = request.body;
+  const {ticket} = request.params;
+  const {agree} = request.body;
   const ticketModel = Ticket.from(ticket);
   const invitee = new Invitee();
   try {
-    request["snug"] = await invitee.joinSnug(ticketModel, agree);
+    request[SNUG] = await invitee.joinSnug(ticketModel, agree);
   } catch (error) {
-    request["invite_snug"] = await invitee.findInvitationByTicket(ticketModel);
+    request[INVITED_SNUG] = await invitee.findInvitationByTicket(ticketModel);
   } finally {
     next();
   }
 };
 
 export const redirectBySnug = (request: Request, response: Response): void => {
-  const snug = request["snug"] || request["invite_snug"];
-  if (!!snug) {
+  const snug = request[SNUG] || request[INVITED_SNUG];
+  const hasSnug = !_.isNil(snug);
+  if (hasSnug) {
     return response.redirect(snug.link);
   }
 
   response.redirect(UrlInfo.aboutHome());
 };
-
 export const responseBySnug = (
-  request: Request,
-  response: Response
+        request: Request,
+        response: Response
 ): Response => {
-  const { agree } = request.body;
-  const snug = request["snug"];
-  const inviteSnug = request["invite_snug"];
-  if (!!snug) {
-    if (agree) {
-      return response.status(ACCEPTED).json(
-        ResponseForm.of<object>(SUCCESS_JOIN_SNUG, { snug: snug })
-      );
-    } else {
-      return response.status(ACCEPTED).json(
-        ResponseForm.of<object>(SUCCESS_REJECT_INVITATION_SNUG, {
-          snug: { link: UrlInfo.aboutHome() }
-        })
-      );
-    }
-  } else if (!!inviteSnug) {
-    return response.status(CONFLICT).json(
-      ResponseForm.of<object>(ALREADY_JOINED_SNUG, { snug: inviteSnug })
-    );
+  const {agree} = request.body;
+  const snug = request[SNUG];
+  const invitedSnug = request[INVITED_SNUG];
+
+  const hasSnug = !_.isNil(snug);
+  const hasInvitedSnug = !_.isNil(invitedSnug);
+
+  const isAcceptInvitation = hasSnug && agree;
+  const isDeclineInvitation = hasSnug && !agree;
+  if (isAcceptInvitation) {
+    return response
+            .status(ACCEPTED)
+            .json(ResponseForm.of<object>(SUCCESS_JOIN_SNUG, {snug: snug}));
+  } else if (isDeclineInvitation) {
+    return response
+            .status(ACCEPTED)
+            .json(ResponseForm.of<object>(SUCCESS_REJECT_INVITATION_SNUG, {
+              snug: {link: UrlInfo.aboutHome()}
+            }));
+  } else if (hasInvitedSnug) {
+    return response
+            .status(CONFLICT)
+            .json(ResponseForm.of<object>(ALREADY_JOINED_SNUG, {snug: invitedSnug}));
   }
 
-  return response.status(FORBIDDEN).json(
-    ResponseForm.of<object>(INVALID_TICKET, {
-      snug: { link: UrlInfo.aboutHome() }
-    })
-  );
+  return response
+          .status(FORBIDDEN)
+          .json(ResponseForm.of<object>(INVALID_TICKET, {
+            snug: {link: UrlInfo.aboutHome()}
+          }));
 };


### PR DESCRIPTION
## Description and Motivation

- 메시지 객체가 초기에 undefined 값을 가지고 있기 때문에, 덧셈을 하지 못해 발생하는 이슈
- 메시지 객체의 replyCount 필드가 undefined 일 경우, 0 으로 대체하여 해결
- 답글에 대해서도 Thread Toggle 이벤트 핸들러 추가

## Types of changes

- [ ] Docs change
- [ ] dependency upgrade
- [ ] refactoring
- [X] Bug fix 
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Review

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.